### PR TITLE
Adding support for Simple checks

### DIFF
--- a/changelogs/fragments/16-create-simple-checks.yaml
+++ b/changelogs/fragments/16-create-simple-checks.yaml
@@ -1,0 +1,6 @@
+breaking_changes:
+  - checks - support creating Simple checks. Previously, C(schedule) and C(tz)
+    were defaulted which made it impossible to differentiate between Simple and
+    Cron checks when creating them. Now, either C(schedule) and C(tz) must be
+    provided to create a Cron check, or, C(timeout) must be provided to create
+    a Simple check (https://github.com/ansible-collections/community.healthchecksio/issues/16).

--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -293,6 +293,16 @@ class Checks(object):
         # uuid is not used to create or update, pop it
         del request_params["uuid"]
 
+        # if schedule and tz, create a Cron check
+        if request_params.get("schedule") and request_params.get("tz"):
+            del request_params["grace"]
+            del request_params["timeout"]
+
+        # if timeout, create a Simple check
+        if request_params.get("timeout"):
+            del request_params["schedule"]
+            del request_params["tz"]
+
         tags = self.module.params.get("tags", [])
         request_params["tags"] = " ".join(tags)
 

--- a/tests/integration/targets/checks/defaults/main.yml
+++ b/tests/integration/targets/checks/defaults/main.yml
@@ -1,1 +1,1 @@
-check_uuid: 8597dcda-23d1-4e6b-b904-83df360bf8a8
+check_uuid: 378767f3-71b6-4e04-b4e2-23adef2a4ad7

--- a/tests/integration/targets/checks/tasks/main.yml
+++ b/tests/integration/targets/checks/tasks/main.yml
@@ -8,12 +8,14 @@
         - api_key is not defined
         - api_key | length == 0
 
-    - name: Create a check named "test"
+    - name: Create a Cron check named "cron test"
       community.healthchecksio.checks:
         state: present
         api_key: "{{ api_key }}"
-        name: test
+        name: cron test
         unique: ["name"]
+        schedule: 7 7 * * *
+        tz: UTC
       register: result
 
     - name: Verify integrations
@@ -22,14 +24,18 @@
           - result.changed
           - result.data is defined
           - result.data.name is defined
-          - result.data.name == "test"
+          - result.data.name == "cron test"
           - result.uuid is defined
 
     - name: Set a fact for the check
       ansible.builtin.set_fact:
         uuid: "{{ result.uuid }}"
 
-    - name: Delete a check named "test"
+    - name: Pause for ten seconds
+      ansible.builtin.pause:
+        seconds: 10
+
+    - name: Delete the Cron check
       community.healthchecksio.checks:
         state: absent
         api_key: "{{ api_key }}"
@@ -42,3 +48,60 @@
           - result.changed
           - result.msg is defined
           - "result.msg == 'Check {{ uuid }} successfully deleted'"
+
+    - name: Create a Simple check named "simple test"
+      community.healthchecksio.checks:
+        state: present
+        api_key: "{{ api_key }}"
+        name: simple test
+        unique: ["name"]
+        timeout: 77
+      register: result
+
+    - name: Verify integrations
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.data is defined
+          - result.data.name is defined
+          - result.data.name == "simple test"
+          - result.uuid is defined
+
+    - name: Set a fact for the check
+      ansible.builtin.set_fact:
+        uuid: "{{ result.uuid }}"
+
+    - name: Pause for ten seconds
+      ansible.builtin.pause:
+        seconds: 10
+
+    - name: Delete the Simple check
+      community.healthchecksio.checks:
+        state: absent
+        api_key: "{{ api_key }}"
+        uuid: "{{ uuid }}"
+      register: result
+
+    - name: Verify integrations
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.msg is defined
+          - "result.msg == 'Check {{ uuid }} successfully deleted'"
+
+    - name: Create an invalid check (mutally exclusive)
+      community.healthchecksio.checks:
+        state: present
+        api_key: "{{ api_key }}"
+        name: simple test
+        unique: ["name"]
+        timeout: 77
+        schedule: 7 7 * * *
+      register: result
+      ignore_errors: true
+
+    - name: Verify integrations
+      ansible.builtin.assert:
+        that:
+          - result.failed
+          - result.msg is search("parameters are mutually exclusive")

--- a/tests/integration/targets/checks_flips_info/defaults/main.yml
+++ b/tests/integration/targets/checks_flips_info/defaults/main.yml
@@ -1,1 +1,1 @@
-check_uuid: 8597dcda-23d1-4e6b-b904-83df360bf8a8
+check_uuid: 378767f3-71b6-4e04-b4e2-23adef2a4ad7

--- a/tests/integration/targets/checks_info/defaults/main.yml
+++ b/tests/integration/targets/checks_info/defaults/main.yml
@@ -1,1 +1,1 @@
-check_uuid: 8597dcda-23d1-4e6b-b904-83df360bf8a8
+check_uuid: 78767f3-71b6-4e04-b4e2-23adef2a4ad7

--- a/tests/integration/targets/checks_info/defaults/main.yml
+++ b/tests/integration/targets/checks_info/defaults/main.yml
@@ -1,1 +1,1 @@
-check_uuid: 78767f3-71b6-4e04-b4e2-23adef2a4ad7
+check_uuid: 378767f3-71b6-4e04-b4e2-23adef2a4ad7

--- a/tests/integration/targets/checks_pings_info/defaults/main.yml
+++ b/tests/integration/targets/checks_pings_info/defaults/main.yml
@@ -1,1 +1,1 @@
-check_uuid: 8597dcda-23d1-4e6b-b904-83df360bf8a8
+check_uuid: 78767f3-71b6-4e04-b4e2-23adef2a4ad7

--- a/tests/integration/targets/checks_pings_info/defaults/main.yml
+++ b/tests/integration/targets/checks_pings_info/defaults/main.yml
@@ -1,1 +1,1 @@
-check_uuid: 78767f3-71b6-4e04-b4e2-23adef2a4ad7
+check_uuid: 378767f3-71b6-4e04-b4e2-23adef2a4ad7

--- a/tests/integration/targets/ping/defaults/main.yml
+++ b/tests/integration/targets/ping/defaults/main.yml
@@ -1,1 +1,1 @@
-check_uuid: 8597dcda-23d1-4e6b-b904-83df360bf8a8
+check_uuid: 78767f3-71b6-4e04-b4e2-23adef2a4ad7

--- a/tests/integration/targets/ping/defaults/main.yml
+++ b/tests/integration/targets/ping/defaults/main.yml
@@ -1,1 +1,1 @@
-check_uuid: 78767f3-71b6-4e04-b4e2-23adef2a4ad7
+check_uuid: 378767f3-71b6-4e04-b4e2-23adef2a4ad7


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support for Simple checks. Previously, `schedule` and `tz` were defaulted, which made it impossible to differentiate between Cron and Simple checks when creating them (to create Simple checks, exclude `schedule` and `tz` and *include* `timeout`).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #16.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- `checks`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

The integration test has been updated to ensure that this works correctly.