### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,21 @@ Community Healthchecks.io Release Notes
 .. contents:: Topics
 
 
+v1.2.0
+======
+
+Restoring the C(grace) parameter to Cron checks and adding Ansible 2.13 to sanity and unit testing.
+
+Minor Changes
+-------------
+
+- ci - adding stable-2.13 to sanity and unit testing (https://github.com/ansible-collections/community.healthchecksio/issues/22).
+
+Bugfixes
+--------
+
+- checks - restore C(grace) parameter to Cron checks (https://github.com/ansible-collections/community.healthchecksio/issues/24).
+
 v1.1.1
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -48,3 +48,14 @@ releases:
     - 16-create-simple-checks.yaml
     - 19-remove-default-uuid.yaml
     release_date: '2022-04-06'
+  1.2.0:
+    changes:
+      release_summary: Restoring the C(grace) parameter to Cron checks and adding Ansible 2.13 to sanity and unit testing.
+      bugfixes:
+      - checks - restore C(grace) parameter to Cron checks (https://github.com/ansible-collections/community.healthchecksio/issues/24).
+      minor_changes:
+      - ci - adding stable-2.13 to sanity and unit testing (https://github.com/ansible-collections/community.healthchecksio/issues/22).
+    fragments:
+    - 22-ci-sanity-2.13.yaml
+    - 24-grace.yaml
+    release_date: '2022-05-19'

--- a/changelogs/fragments/22-ci-sanity-2.13.yaml
+++ b/changelogs/fragments/22-ci-sanity-2.13.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - ci - adding stable-2.13 to sanity and unit testing (https://github.com/ansible-collections/community.healthchecksio/issues/22).

--- a/changelogs/fragments/24-grace.yaml
+++ b/changelogs/fragments/24-grace.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - checks - restore C(grace) parameter to Cron checks (https://github.com/ansible-collections/community.healthchecksio/issues/24).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: healthchecksio
-version: 1.1.1
+version: 1.2.0
 readme: README.md
 authors:
   - Mark Mercado (https://github.com/mamercad)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Release 1.2.0; restoring the `grace` parameter to Cron checks and adding Ansible 2.13 to sanity and unit testing.
