### PR TITLE
Allow setting custom API URL for self hosted instances

### DIFF
--- a/plugins/doc_fragments/healthchecksio.py
+++ b/plugins/doc_fragments/healthchecksio.py
@@ -18,4 +18,11 @@ options:
       - C(HEALTHCHECKSIO_API_TOKEN), C(HEALTHCHECKSIO_API_KEY), C(HC_API_TOKEN), C(HC_API_KEY)
     type: str
     required: true
+  api_url:
+    description:
+      - Healthchecks.io API url, if using a self hosted instance.
+      - "There are several environment variables which can be used to provide this value:"
+      - C(HEALTHCHECKSIO_API_URL), C(HC_API_URL)
+    type: str
+    required: false
 """

--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -42,7 +42,7 @@ class Response(object):
 class HealthchecksioHelper:
     def __init__(self, module):
         self.module = module
-        self.baseurl = "https://healthchecks.io/api/v1"
+        self.baseurl = module.params.get("api_url") or "https://healthchecks.io/api/v1"
         self.timeout = module.params.get("timeout", 30)
         self.api_token = module.params.get("api_token")
         self.headers = {"X-Api-Key": self.api_token}
@@ -90,7 +90,7 @@ class HealthchecksioHelper:
     def head(self, path, data=None):
         resp, info = fetch_url(
             self.module,
-            "https://hc-ping.com/{0}".format(path),
+            "{baseurl}/{path}".format(baseurl=self.baseurl,path=path),
             data=data,
             headers=self.headers,
             method="HEAD",
@@ -116,6 +116,18 @@ class HealthchecksioHelper:
                 ),
                 required=True,
                 no_log=True,
+            ),
+            api_url=dict(
+                type="str",
+                fallback=(
+                    env_fallback,
+                    [
+                        "HEALTHCHECKSIO_API_URL",
+                        "HC_API_URL",
+                    ],
+                ),
+                required=False,
+                no_log=False,
             ),
         )
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add the ability to override the default API url so this collection can be used with self-hosted instances of healthchecks.io.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

I also had to change the short ping_url from https://hc-ping.com to use the full base url, because self hosted instances don't (necessarily) have a separate shorter domain for pinging healthchecks.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

    - name: Get check info
      community.healthchecksio.checks_info:
        api_url: "https://example.domain.com/api/v1"
        api_token: "api token"

```
