### PR TITLE
Compare channel sets as equal

### DIFF
--- a/changelogs/fragments/120-compare-channel-sets-as-equal.yaml
+++ b/changelogs/fragments/120-compare-channel-sets-as-equal.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - checks - channel comparison result was order dependent. Fix now compares channels lists as sets (https://github.com/ansible-collections/community.healthchecksio/pull/35).

--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -336,7 +336,7 @@ class Checks(object):
                 for k in request_params
                 if k not in skip_idempotency_params
             )
-            and c[0]["channels"] == channels
+            and sorted(c[0]["channels"].split(",")) == sorted(channels.split(","))
         ):
             self.module.exit_json(changed=False, data=c[0], uuid=self.get_uuid(c[0]))
 


### PR DESCRIPTION
The order of a channel list shouldn't matter as long as the same channels are included.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The change compares the channel lists of the request and an existing check as sets such that the channel order doesn't matter.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
checks

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

I ran into this while integrating existing checks (that were created via the Web UI) in a healthchecks playbook.
In the playbook I'm using the default `*` channel list joker.
My healthchecks account and checks of 2 notification channels configured.

