### PR TITLE
Release v1.3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Community Healthchecks.io Release Notes
 .. contents:: Topics
 
 
+v1.3.1
+======
+
+Bugfixes
+--------
+
+- checks - channel comparison result was order dependent. Fix now compares channels lists as sets (https://github.com/ansible-collections/community.healthchecksio/pull/35).
+
 v1.3.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -50,20 +50,29 @@ releases:
     release_date: '2022-04-06'
   1.2.0:
     changes:
-      release_summary: Restoring the C(grace) parameter to Cron checks and adding Ansible 2.13 to sanity and unit testing.
       bugfixes:
       - checks - restore C(grace) parameter to Cron checks (https://github.com/ansible-collections/community.healthchecksio/issues/24).
       minor_changes:
       - ci - adding stable-2.13 to sanity and unit testing (https://github.com/ansible-collections/community.healthchecksio/issues/22).
+      release_summary: Restoring the C(grace) parameter to Cron checks and adding
+        Ansible 2.13 to sanity and unit testing.
     fragments:
     - 22-ci-sanity-2.13.yaml
     - 24-grace.yaml
     release_date: '2022-05-19'
   1.3.0:
     changes:
-      release_summary: Implement idempotency when unique param is used in checks.
       minor_changes:
       - checks - implement idempotency when unique param is used (https://github.com/ansible-collections/community.healthchecksio/issues/28)
+      release_summary: Implement idempotency when unique param is used in checks.
     fragments:
     - 29-idempotency.yaml
     release_date: '2023-03-10'
+  1.3.1:
+    changes:
+      bugfixes:
+      - checks - channel comparison result was order dependent. Fix now compares channels
+        lists as sets (https://github.com/ansible-collections/community.healthchecksio/pull/35).
+    fragments:
+    - 120-compare-channel-sets-as-equal.yaml
+    release_date: '2023-08-03'

--- a/changelogs/fragments/120-compare-channel-sets-as-equal.yaml
+++ b/changelogs/fragments/120-compare-channel-sets-as-equal.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - checks - channel comparison result was order dependent. Fix now compares channels lists as sets (https://github.com/ansible-collections/community.healthchecksio/pull/35).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: healthchecksio
-version: 1.3.0
+version: 1.3.1
 readme: README.md
 authors:
   - Mark Mercado (https://github.com/mamercad)


### PR DESCRIPTION
v1.3.1
======

Bugfixes
--------

- checks - channel comparison result was order dependent. Fix now compares channels lists as sets (https://github.com/ansible-collections/community.healthchecksio/pull/35).