### PR TITLE
Enable self-hosted healthchecks.io instances

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,11 +4,6 @@ Community Healthchecks.io Release Notes
 
 .. contents:: Topics
 
-### [Unreleased]
-
-### Added
-
-- Support for using a private instance of Healthchecks.io
 
 v1.2.0
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Community Healthchecks.io Release Notes
 
 .. contents:: Topics
 
+### [Unreleased]
+
+### Added
+
+- Support for using a private instance of Healthchecks.io
 
 v1.2.0
 ======

--- a/README.md
+++ b/README.md
@@ -210,9 +210,8 @@ N/A
     signal: start
 ```
 
-### Using a Private Instance of Healthchecks.io
-
-The `api_base_url` variable allows you to specify the custom API URL of your healthchecks.io instance, which can be used to connect to your private instance.
+### Using a self-hosted instance of Healthchecks.io
+The `api_base_url` parameter can be used to direct the modules in this Collection towards a self-hosted instance of Healthchecks.io. By default, or if unset, it defaults to the public instance located at hc-ping.com.
 
 Example Ansible configuration using the `api_base_url` variable:
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,22 @@ N/A
     signal: start
 ```
 
+### Using a Private Instance of Healthchecks.io
+
+The `api_base_url` variable allows you to specify the custom API URL of your healthchecks.io instance, which can be used to connect to your private instance.
+
+Example Ansible configuration using the `api_base_url` variable:
+
+```yaml
+- name: Create a check named "test"
+  community.healthchecksio.checks:
+    state: present
+    api_base_url: {{ api_base_url }}
+    api_key: "{{ api_key }}"
+    name: test
+    unique: ["name"]
+```
+
 ### Installing the Collection from Ansible Galaxy
 
 Before using this collection, you need to install it with the Ansible Galaxy command-line tool:

--- a/changelogs/fragments/32-selfhosted.yaml
+++ b/changelogs/fragments/32-selfhosted.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - base_url - Support for using a private instance of Healthchecks.io (https://github.com/ansible-collections/community.healthchecksio/pull/32).

--- a/changelogs/fragments/32-selfhosted.yaml
+++ b/changelogs/fragments/32-selfhosted.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Support for using a private instance of Healthchecks.io (https://github.com/ansible-collections/community.healthchecksio/pull/37).
+  - Add support for using self-hosted instances of Healthchecks.io (https://github.com/ansible-collections/community.healthchecksio/pull/37).

--- a/changelogs/fragments/32-selfhosted.yaml
+++ b/changelogs/fragments/32-selfhosted.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - base_url - Support for using a private instance of Healthchecks.io (https://github.com/ansible-collections/community.healthchecksio/pull/32).
+  - Support for using a private instance of Healthchecks.io (https://github.com/ansible-collections/community.healthchecksio/pull/37).

--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -293,7 +293,7 @@ class Checks(object):
     def get_uuid(self, json_data):
         ping_url = json_data.get("ping_url", None)
         if ping_url is not None:
-            uuid = ping_url.split("/")[3]
+            uuid = ping_url.split("/")[-1]
             if len(uuid) > 0:
                 return uuid
             else:

--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -133,7 +133,7 @@ class HealthchecksioHelper:
                 ),
                 required=False,
                 no_log=True,
-                default="https://healthchecks.io",
+                default="https://hc-ping.com",
             ),
         )
 

--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -44,7 +44,9 @@ class HealthchecksioHelper:
     def __init__(self, module):
         self.module = module
         api_base_url = module.params.get("api_base_url")
-        if api_base_url == self.healthchecksio_argument_spec().get("api_base_url").get("default"):
+        if api_base_url == self.healthchecksio_argument_spec().get("api_base_url").get(
+            "default"
+        ):
             self.ping_api_base_url = "https://hc-ping.com"
         else:
             self.ping_api_base_url = urljoin(api_base_url, "/ping")
@@ -127,14 +129,11 @@ class HealthchecksioHelper:
                 type="str",
                 fallback=(
                     env_fallback,
-                    [
-                        "HEALTHCHECKSIO_API_BASE_URL",
-                        "HC_API_BASE_URL"
-                    ],
+                    ["HEALTHCHECKSIO_API_BASE_URL", "HC_API_BASE_URL"],
                 ),
                 required=False,
                 no_log=True,
-                default="https://healthchecks.io"
+                default="https://healthchecks.io",
             ),
         )
 
@@ -347,7 +346,7 @@ class Checks(object):
             channels = request_params["channels"]
 
         # If all request parameters (except unique and api_key) match, exit without changes
-        skip_idempotency_params = ["unique", "api_key", "channels"]
+        skip_idempotency_params = ["unique", "api_key", "api_base_url", "channels"]
         if (
             len(c) == 1
             and all(

--- a/plugins/modules/checks.py
+++ b/plugins/modules/checks.py
@@ -208,6 +208,7 @@ def main():
         channels=dict(type="str", required=False, default=""),
         unique=dict(type="list", elements="str", required=False, default=[]),
         uuid=dict(type="str", required=False, default=""),
+        slug=dict(type="str", required=False, default=""),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,


### PR DESCRIPTION
Issues #27 and #32 address supporting self-hosted instances.
This PR is a continuation of #32 

Notably line plugins/module_utils/healthchecksio.py#349 needed to have the `api_base_url` added to allow checks to be made.
