### PR TITLE
Fix integration test concurrency

### DIFF
--- a/.github/workflows/ansible-test-integration.yml
+++ b/.github/workflows/ansible-test-integration.yml
@@ -10,8 +10,8 @@ on:
     - cron: '10 6 * * *'
 
 concurrency:
-  group: cloud-integration-tests
-  cancel-in-progress: false
+  group: "${{ github.workflow }}"
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/pull-request-integration.yml
+++ b/.github/workflows/pull-request-integration.yml
@@ -6,8 +6,8 @@ on:
     types: [ opened, synchronize, reopened ]
 
 concurrency:
-  group: cloud-integration-tests
-  cancel-in-progress: false
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
 
 jobs:
 

--- a/changelogs/fragments/38-integration-test-concurrency.yml
+++ b/changelogs/fragments/38-integration-test-concurrency.yml
@@ -1,2 +1,0 @@
-trivial:
-  - ci - Fix integration test concurrency (https://github.com/ansible-collections/community.healthchecksio/pull/38).

--- a/changelogs/fragments/38-integration-test-concurrency.yml
+++ b/changelogs/fragments/38-integration-test-concurrency.yml
@@ -1,0 +1,2 @@
+trivial:
+  - ci - Fix integration test concurrency (https://github.com/ansible-collections/community.healthchecksio/pull/38).

--- a/changelogs/fragments/39-integration-test-concurrency.yml
+++ b/changelogs/fragments/39-integration-test-concurrency.yml
@@ -1,0 +1,2 @@
+trivial:
+  - ci - Fix integration test concurrency (https://github.com/ansible-collections/community.healthchecksio/pull/39).


### PR DESCRIPTION
Currently, the integration testing workflows are (unnecessarily) colliding.