### PR TITLE
Compatibility with self-hosted instances 

### DIFF
--- a/.github/workflows/ansible-test-integration.yml
+++ b/.github/workflows/ansible-test-integration.yml
@@ -33,3 +33,25 @@ jobs:
           target-python-version: 3.8
           testing-type: integration
           test-deps: community.general
+
+  integration_self_hosted:
+    environment: integration_self_hosted
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Perform testing self-hosted
+        uses: ansible-community/ansible-test-gh-action@release/v1
+        with:
+          # ansible-core-version:
+          pre-test-cmd: >-  # Configure integration test run
+            MANAGEMENT_API_TOKEN=${{ secrets.MANAGEMENT_API_TOKEN }}
+            MANAGEMENT_API_BASE_URL=${{ secrets.MANAGEMENT_API_BASE_URL }}
+            PING_API_BASE_URL=${{ secrets.PING_API_BASE_URL }}
+            ./tests/utils/render.sh
+            tests/integration/integration_config.yml.template
+            > tests/integration/integration_config.yml
+          python-version: 3.9
+          target-python-version: 3.8
+          testing-type: integration
+          test-deps: community.general

--- a/.github/workflows/pull-request-integration.yml
+++ b/.github/workflows/pull-request-integration.yml
@@ -33,3 +33,28 @@ jobs:
           target-python-version: 3.8
           testing-type: integration
           test-deps: community.general
+
+  integration_self_hosted:
+    # Require reviewers for this environment
+    # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+    environment: integration_self_hosted
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Perform testing self-hosted
+        uses: ansible-community/ansible-test-gh-action@release/v1
+        with:
+          # ansible-core-version:
+          git-checkout-ref: ${{ github.event.pull_request.head.sha }} # Check out the pull request
+          pre-test-cmd: >-  # Configure integration test run
+            MANAGEMENT_API_TOKEN=${{ secrets.MANAGEMENT_API_TOKEN }}
+            MANAGEMENT_API_BASE_URL=${{ secrets.MANAGEMENT_API_BASE_URL }}
+            PING_API_BASE_URL=${{ secrets.PING_API_BASE_URL }}
+            ./tests/utils/render.sh
+            tests/integration/integration_config.yml.template
+            > tests/integration/integration_config.yml
+          python-version: 3.9
+          target-python-version: 3.8
+          testing-type: integration
+          test-deps: community.general

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /tests/output/
 /tests/integration/integration_config.yml
+/tests/integration/inventory
 /changelogs/.plugin-cache.yaml
 
 # Byte-compiled / optimized / DLL files

--- a/README.md
+++ b/README.md
@@ -210,6 +210,23 @@ N/A
     signal: start
 ```
 
+### Using a self-hosted instance of Healthchecks.io
+
+The `management_api_base_url` and `ping_api_base_url` parameters can be used to direct the modules in this Collection towards a self-hosted instance of Healthchecks.io. By default, or if unset, it defaults to the public instance located at hc-ping.com.
+
+Example Ansible configuration using the `management_api_base_url` and `ping_api_base_url` variables:
+
+```yaml
+- name: Create a check named "test"
+  community.healthchecksio.checks:
+    state: present
+    api_key: "{{ api_key }}"
+    management_api_base_url: "{{ management_api_base_url }}"
+    ping_api_base_url: "{{ ping_api_base_url }}"
+    name: test
+    unique: ["name"]
+```
+
 ### Installing the Collection from Ansible Galaxy
 
 Before using this collection, you need to install it with the Ansible Galaxy command-line tool:

--- a/changelogs/fragments/43-compatibility-with-selfhosted-instances.yml
+++ b/changelogs/fragments/43-compatibility-with-selfhosted-instances.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add support for using self-hosted instances of Healthchecks.io (https://github.com/ansible-collections/community.healthchecksio/pull/43)

--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -10,6 +10,7 @@ import json
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import env_fallback
+from urllib.parse import urljoin
 
 
 class Response(object):
@@ -42,19 +43,27 @@ class Response(object):
 class HealthchecksioHelper:
     def __init__(self, module):
         self.module = module
-        self.baseurl = "https://healthchecks.io/api/v1"
+        self.base_url = self._get_base_url(module)
+        self.api_token = self._get_api_token(module)
         self.timeout = module.params.get("timeout", 30)
-        self.api_token = module.params.get("api_token")
         self.headers = {"X-Api-Key": self.api_token}
 
         response = self.get("checks")
         if response.status_code == 401:
-            self.module.fail_json(msg="Failed to login using API token")
+            self.module.fail_json(
+                msg="Failed to login using API token against {0}".format(self.base_url)
+            )
+
+    def _get_api_token(self, module):
+        return module.params.get("management_api_token")
+
+    def _get_base_url(self, module):
+        return module.params.get("management_api_base_url")
 
     def _url_builder(self, path):
         if path[0] == "/":
             path = path[1:]
-        return "%s/%s" % (self.baseurl, path)
+        return "%s/%s" % (self.base_url, path)
 
     def send(self, method, path, data=None):
         url = self._url_builder(path)
@@ -87,37 +96,98 @@ class HealthchecksioHelper:
     def delete(self, path, data=None):
         return self.send("DELETE", path, data)
 
-    def head(self, path, data=None):
-        resp, info = fetch_url(
-            self.module,
-            "https://hc-ping.com/{0}".format(path),
-            data=data,
-            headers=self.headers,
-            method="HEAD",
-            timeout=self.timeout,
-        )
+    def head(self, path, data=None, no_headers=False):
+        uri = "{0}/{1}".format(self.base_url, path)
+        if no_headers is True:
+            resp, info = fetch_url(
+                self.module,
+                uri,
+                data=data,
+                method="HEAD",
+                timeout=self.timeout,
+            )
+        else:
+            resp, info = fetch_url(
+                self.module,
+                uri,
+                data=data,
+                headers=self.headers,
+                method="HEAD",
+                timeout=self.timeout,
+            )
         return Response(resp, info)
 
     @staticmethod
     def healthchecksio_argument_spec():
         return dict(
             state=dict(type="str", choices=["present", "absent"], default="present"),
-            api_token=dict(
+            management_api_token=dict(
                 type="str",
-                aliases=["api_key"],
+                aliases=[
+                    "management_api_key",
+                    "api_key",
+                ],
                 fallback=(
                     env_fallback,
                     [
-                        "HEALTHCHECKSIO_API_TOKEN",
-                        "HEALTHCHECKSIO_API_KEY",
-                        "HC_API_TOKEN",
-                        "HC_API_KEY",
+                        "HEALTHCHECKSIO_MANAGEMENT_API_KEY",
+                        "HC_MANAGEMENT_API_KEY",
+                        "HC_MANAGEMENT_KEY",
                     ],
                 ),
-                required=True,
+                required=False,
+                no_log=True,
+            ),
+            management_api_base_url=dict(
+                type="str",
+                fallback=(
+                    env_fallback,
+                    [
+                        "HEALTHCHECKSIO_API_MANAGEMENT_BASE_URL",
+                        "HC_API_MANAGEMENT_BASE_URL",
+                    ],
+                ),
+                required=False,
+                no_log=False,
+                default="https://healthchecks.io/api/v1",
+            ),
+            ping_api_base_url=dict(
+                type="str",
+                fallback=(
+                    env_fallback,
+                    [
+                        "HEALTHCHECKSIO_API_PING_BASE_URL",
+                        "HC_API_PING_BASE_URL",
+                    ],
+                ),
+                required=False,
+                no_log=False,
+                default="https://hc-ping.com",
+            ),
+            ping_api_token=dict(
+                type="str",
+                fallback=(
+                    env_fallback,
+                    [
+                        "HEALTHCHECKSIO_API_PING_KEY",
+                        "HC_API_PING_KEY",
+                    ],
+                ),
+                required=False,
                 no_log=True,
             ),
         )
+
+
+class HealthchecksioPingHelper(HealthchecksioHelper):
+    def _get_api_token(self, module):
+        # We can use the management API token instead of the ping token
+        if module.params.get("ping_api_token") != "":
+            return module.params.get("ping_api_token")
+        return module.params.get("management_api_token")
+
+    def _get_base_url(self, module):
+        return module.params.get("ping_api_base_url")
 
 
 class BadgesInfo(object):
@@ -269,12 +339,11 @@ class Checks(object):
     def __init__(self, module):
         self.module = module
         self.rest = HealthchecksioHelper(module)
-        self.api_token = module.params.pop("api_token")
 
     def get_uuid(self, json_data):
         ping_url = json_data.get("ping_url", None)
         if ping_url is not None:
-            uuid = ping_url.split("/")[3]
+            uuid = ping_url.split("/")[-1]
             if len(uuid) > 0:
                 return uuid
             else:
@@ -328,7 +397,17 @@ class Checks(object):
             channels = request_params["channels"]
 
         # If all request parameters (except unique and api_key) match, exit without changes
-        skip_idempotency_params = ["unique", "api_key", "channels"]
+        skip_idempotency_params = [
+            "unique",
+            "api_key",  # Kept for backward compatibility
+            "management_api_key",
+            "management_api_token",
+            "management_api_base_url",
+            "ping_api_key",
+            "ping_api_base_url",
+            "ping_api_token",
+            "channels",
+        ]
         if (
             len(c) == 1
             and all(
@@ -418,8 +497,7 @@ class Checks(object):
 class Ping(object):
     def __init__(self, module):
         self.module = module
-        self.rest = HealthchecksioHelper(module)
-        self.api_token = module.params.pop("api_token")
+        self.rest = HealthchecksioPingHelper(module)
 
     def create(self, uuid, signal):
         if self.module.check_mode:
@@ -430,7 +508,7 @@ class Ping(object):
         else:
             endpoint = "{0}/{1}".format(uuid, signal)
 
-        response = self.rest.head(endpoint)
+        response = self.rest.head(endpoint, no_headers=True)
         status_code = response.status_code
 
         if status_code == 200:
@@ -442,6 +520,6 @@ class Ping(object):
             self.module.fail_json(
                 changed=False,
                 msg="Failed to send {0} signal to {1} [HTTP {2}]".format(
-                    signal, endpoint, status_code
+                    signal, response.info, status_code
                 ),
             )

--- a/plugins/modules/checks.py
+++ b/plugins/modules/checks.py
@@ -208,6 +208,7 @@ def main():
         channels=dict(type="str", required=False, default=""),
         unique=dict(type="list", elements="str", required=False, default=[]),
         uuid=dict(type="str", required=False, default=""),
+        slug=dict(type="str", required=False, default=""),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/tests/integration/integration_config.yml.template
+++ b/tests/integration/integration_config.yml.template
@@ -1,2 +1,5 @@
 ---
-api_key: ${HEALTHCHECKSIO_API_TOKEN}
+api_key: ${MANAGEMENT_API_TOKEN:-$HEALTHCHECKSIO_API_TOKEN}
+management_api_base_url: ${MANAGEMENT_API_BASE_URL:-"https://healthchecks.io/api/v1"}
+ping_api_base_url: ${PING_API_BASE_URL:-"https://hc-ping.com"}
+ping_api_token: ${PING_API_TOKEN:-""}

--- a/tests/integration/targets/badges_info/tasks/main.yml
+++ b/tests/integration/targets/badges_info/tasks/main.yml
@@ -11,6 +11,8 @@
     - name: Get the project badges
       community.healthchecksio.badges_info:
         api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
       register: result
 
     - name: Verify project badges

--- a/tests/integration/targets/channels_info/tasks/main.yml
+++ b/tests/integration/targets/channels_info/tasks/main.yml
@@ -11,6 +11,8 @@
     - name: Get the list of integrations
       community.healthchecksio.channels_info:
         api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
       register: result
 
     - name: Verify integrations

--- a/tests/integration/targets/checks/defaults/main.yml
+++ b/tests/integration/targets/checks/defaults/main.yml
@@ -1,3 +1,2 @@
-check_uuid: 378767f3-71b6-4e04-b4e2-23adef2a4ad7
 schedule: 7 7 * * *
 grace: 77

--- a/tests/integration/targets/checks/tasks/main.yml
+++ b/tests/integration/targets/checks/tasks/main.yml
@@ -13,6 +13,8 @@
         state: present
         channels: "*"  # also test idempotency for channels
         api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
         name: cron test
         unique: ["name"]
         schedule: 7 7 * * *
@@ -24,6 +26,8 @@
         state: present
         channels: "*"  # also test idempotency for channels
         api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
         name: cron test
         unique: ["name"]
         schedule: 7 7 * * *
@@ -52,6 +56,8 @@
       community.healthchecksio.checks:
         state: absent
         api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
         uuid: "{{ uuid }}"
       register: result
 
@@ -66,6 +72,8 @@
       community.healthchecksio.checks:
         state: present
         api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
         name: simple test
         unique: ["name"]
         timeout: 77
@@ -92,6 +100,8 @@
       community.healthchecksio.checks:
         state: absent
         api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
         uuid: "{{ uuid }}"
       register: result
 
@@ -106,6 +116,8 @@
       community.healthchecksio.checks:
         state: present
         api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
         name: simple test
         unique: ["name"]
         timeout: 77
@@ -123,6 +135,8 @@
       community.healthchecksio.checks:
         state: present
         api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
         name: cron test grace
         unique: ["name"]
         schedule: "{{ schedule }}"
@@ -153,6 +167,8 @@
       community.healthchecksio.checks:
         state: absent
         api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
         uuid: "{{ uuid }}"
       register: result
 
@@ -167,6 +183,8 @@
       community.healthchecksio.checks:
         state: present
         api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
         name: simple test
         unique: ["name"]
         timeout: 77
@@ -193,6 +211,8 @@
       community.healthchecksio.checks:
         state: absent
         api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
         uuid: "{{ uuid }}"
       register: result
 

--- a/tests/integration/targets/checks_flips_info/defaults/main.yml
+++ b/tests/integration/targets/checks_flips_info/defaults/main.yml
@@ -1,1 +1,0 @@
-check_uuid: 378767f3-71b6-4e04-b4e2-23adef2a4ad7

--- a/tests/integration/targets/checks_flips_info/tasks/main.yml
+++ b/tests/integration/targets/checks_flips_info/tasks/main.yml
@@ -7,11 +7,40 @@
       when:
         - api_key is not defined
         - api_key | length == 0
+    - name: Create a Simple check named "simple test"
+      community.healthchecksio.checks:
+        state: present
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        name: simple test
+        unique: ["name"]
+        timeout: 77
+      register: result
+
+    - name: Verify integrations
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.data is defined
+          - result.data.name is defined
+          - result.data.name == "simple test"
+          - result.uuid is defined
+
+    - name: Set a fact for the check
+      ansible.builtin.set_fact:
+        uuid: "{{ result.uuid }}"
+
+    - name: Pause for ten seconds
+      ansible.builtin.pause:
+        seconds: 10
 
     - name: Get the list check flips
       community.healthchecksio.checks_flips_info:
         api_key: "{{ api_key }}"
-        uuid: "{{ check_uuid }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        uuid: "{{ uuid }}"
       register: result
 
     - name: Verify integrations
@@ -20,3 +49,23 @@
           - not result.changed
           - result.data is defined
           - result.data.flips is defined
+
+    - name: Pause for ten seconds
+      ansible.builtin.pause:
+        seconds: 10
+
+    - name: Delete the Simple check
+      community.healthchecksio.checks:
+        state: absent
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        uuid: "{{ uuid }}"
+      register: result
+
+    - name: Verify integrations
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.msg is defined
+          - result.msg == "Check " ~ uuid ~ " successfully deleted"

--- a/tests/integration/targets/checks_info/defaults/main.yml
+++ b/tests/integration/targets/checks_info/defaults/main.yml
@@ -1,1 +1,0 @@
-check_uuid: 378767f3-71b6-4e04-b4e2-23adef2a4ad7

--- a/tests/integration/targets/checks_info/tasks/main.yml
+++ b/tests/integration/targets/checks_info/tasks/main.yml
@@ -11,6 +11,8 @@
     - name: Get the list of checks
       community.healthchecksio.checks_info:
         api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
       register: result
 
     - name: Verify integrations

--- a/tests/integration/targets/checks_pings_info/defaults/main.yml
+++ b/tests/integration/targets/checks_pings_info/defaults/main.yml
@@ -1,1 +1,0 @@
-check_uuid: 378767f3-71b6-4e04-b4e2-23adef2a4ad7

--- a/tests/integration/targets/checks_pings_info/tasks/main.yml
+++ b/tests/integration/targets/checks_pings_info/tasks/main.yml
@@ -8,10 +8,40 @@
         - api_key is not defined
         - api_key | length == 0
 
+    - name: Create a Simple check named "simple test"
+      community.healthchecksio.checks:
+        state: present
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        name: simple test
+        unique: ["name"]
+        timeout: 77
+      register: result
+
+    - name: Verify integrations
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.data is defined
+          - result.data.name is defined
+          - result.data.name == "simple test"
+          - result.uuid is defined
+
+    - name: Set a fact for the check
+      ansible.builtin.set_fact:
+        uuid: "{{ result.uuid }}"
+
+    - name: Pause for ten seconds
+      ansible.builtin.pause:
+        seconds: 10
+
     - name: Get the list of check pings
       community.healthchecksio.checks_pings_info:
         api_key: "{{ api_key }}"
-        uuid: "{{ check_uuid }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        uuid: "{{ uuid }}"
       register: result
 
     - name: Verify integrations
@@ -20,3 +50,23 @@
           - not result.changed
           - result.data is defined
           - result.data.pings is defined
+
+    - name: Pause for ten seconds
+      ansible.builtin.pause:
+        seconds: 10
+
+    - name: Delete the Simple check
+      community.healthchecksio.checks:
+        state: absent
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        uuid: "{{ uuid }}"
+      register: result
+
+    - name: Verify integrations
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.msg is defined
+          - result.msg == "Check " ~ uuid ~ " successfully deleted"

--- a/tests/integration/targets/ping/defaults/main.yml
+++ b/tests/integration/targets/ping/defaults/main.yml
@@ -1,1 +1,0 @@
-check_uuid: 378767f3-71b6-4e04-b4e2-23adef2a4ad7

--- a/tests/integration/targets/ping/tasks/main.yml
+++ b/tests/integration/targets/ping/tasks/main.yml
@@ -8,26 +8,61 @@
         - api_key is not defined
         - api_key | length == 0
 
+    - name: Create a Simple check named "simple test"
+      community.healthchecksio.checks:
+        state: present
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        name: simple test
+        unique: ["name"]
+        timeout: 77
+      register: result
+
+    - name: Verify integrations
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.data is defined
+          - result.data.name is defined
+          - result.data.name == "simple test"
+          - result.uuid is defined
+
+    - name: Set a fact for the check
+      ansible.builtin.set_fact:
+        uuid: "{{ result.uuid }}"
+
+    - name: Pause for ten seconds
+      ansible.builtin.pause:
+        seconds: 10
+
     - name: Send start signal
       community.healthchecksio.ping:
         state: present
         api_key: "{{ api_key }}"
-        uuid: "{{ check_uuid }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        uuid: "{{ uuid }}"
         signal: start
       register: result
 
+    - name: Debug result
+      ansible.builtin.debug:
+        var: result
     - name: Verify start signal
       ansible.builtin.assert:
         that:
           - result.changed
           - result.msg is defined
-          - "result.msg == 'Sent start signal to {{ check_uuid }}/start'"
+          - "result.msg == 'Sent start signal to ' + uuid + '/start'"
 
     - name: Send fail signal
       community.healthchecksio.ping:
         state: present
         api_key: "{{ api_key }}"
-        uuid: "{{ check_uuid }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        uuid: "{{ uuid }}"
         signal: fail
       register: result
 
@@ -36,13 +71,15 @@
         that:
           - result.changed
           - result.msg is defined
-          - "result.msg == 'Sent fail signal to {{ check_uuid }}/fail'"
+          - "result.msg == 'Sent fail signal to ' + uuid + '/fail'"
 
     - name: Send success signal
       community.healthchecksio.ping:
         state: present
         api_key: "{{ api_key }}"
-        uuid: "{{ check_uuid }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        uuid: "{{ uuid }}"
         signal: success
       register: result
 
@@ -51,4 +88,13 @@
         that:
           - result.changed
           - result.msg is defined
-          - "result.msg == 'Sent success signal to {{ check_uuid }}'"
+          - "result.msg == 'Sent success signal to ' + uuid"
+
+    - name: Delete the Simple check
+      community.healthchecksio.checks:
+        state: absent
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        uuid: "{{ uuid }}"
+      register: result

--- a/tests/utils/render.sh
+++ b/tests/utils/render.sh
@@ -9,7 +9,10 @@ set -u
 function main()
 {
   readonly template="$1"; shift
-  readonly content="$(cat "$template")"
+
+  local content
+  content="$(cat "$template")"
+  readonly content
 
   eval "echo \"$content\""
 }


### PR DESCRIPTION
##### SUMMARY

Hi Mark,

Thank you for your job on this healthchecks collection.

I'd like to add the compatibility with self-hosted instances, allowing me to provision my servers with IaC.

This PR is addressing the self-hosting need, I took the work from the PR #32 (Thanks to @Penagwin) and I started working from this.

There is no breaking changes, everything is backward compatible (i.e. `api_token` is still being used and all URLs point back to healthchecks.io infrastructure) 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Entire project

##### ADDITIONAL INFORMATION

I added two ci integrations for self-hosted, on PR and also when pushing to master & by the cron