### PR TITLE
fix: replace deprecated ansible.module_utils._text import

### DIFF
--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 import json
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import env_fallback
 
 


### PR DESCRIPTION
Hey folks - I've been encountering this deprecation warning while using this very handy collection. Just wanted to offer a patch that got rid of it - seeing purple in the plays makes my left eye twitch. ;)

## Summary

`ansible.module_utils._text` is a private module deprecated since ansible-core 2.17 and scheduled for removal in 2.24.

Running any module from this collection currently emits:

```
[DEPRECATION WARNING]: Importing 'to_text' from 'ansible.module_utils._text' is deprecated.
This feature will be removed from ansible-core version 2.24.
Use ansible.module_utils.common.text.converters instead.
```

`to_text` is available at the canonical public path `ansible.module_utils.common.text.converters` (stable since ansible-core 2.8). The behaviour is identical — this is a drop-in import change.

## Change

`plugins/module_utils/healthchecksio.py`:

```diff
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
```
