### PR TITLE
Add changelog fragment for PR #46

### DIFF
--- a/changelogs/fragments/46-fix-deprecated-module-utils-text.yml
+++ b/changelogs/fragments/46-fix-deprecated-module-utils-text.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - community.healthchecksio.checks - Replace deprecated ``ansible.module_utils._text`` import with ``ansible.module_utils.common.text.converters`` (https://github.com/ansible-collections/community.healthchecksio/pull/46).

--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 import json
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import env_fallback
 
 


### PR DESCRIPTION
This PR adds the required changelog fragment for the upstream PR #46 (fix: replace deprecated ansible.module_utils._text import). The upstream author doesn't have permission to push to the collection repo, so I'm opening this from the maintainer's fork.