### PR TITLE
Release v1.3.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Community Healthchecks.io Release Notes
 .. contents:: Topics
 
 
+v1.3.2
+======
+
+Bugfixes
+--------
+
+- Replace deprecated ``ansible.module_utils._text`` import with ``ansible.module_utils.common.text.converters`` (https://github.com/ansible-collections/community.healthchecksio/pull/46).
+
 v1.3.1
 ======
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: healthchecksio
-version: 1.3.1
+version: 1.3.2
 readme: README.md
 authors:
   - Mark Mercado (https://github.com/mamercad)


### PR DESCRIPTION
Release commit: bump version to 1.3.2 and update CHANGELOG. Ready for tagging and publishing to Galaxy.