### PR TITLE
fix: read-only info modules honor check mode (GET data)

### DIFF
--- a/changelogs/fragments/34-info-get-check-mode.yml
+++ b/changelogs/fragments/34-info-get-check-mode.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >-
+    badges_info, channels_info, checks_flips_info, checks_info, and checks_pings_info
+    perform read-only GET requests in check mode instead of returning empty data
+    (https://github.com/ansible-collections/community.healthchecksio/issues/34).

--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -204,9 +204,6 @@ class BadgesInfo(object):
         self.rest = HealthchecksioHelper(module)
 
     def get(self):
-        if self.module.check_mode:
-            self.module.exit_json(changed=False, data={})
-
         endpoint = "badges"
 
         response = self.rest.get(endpoint)
@@ -232,9 +229,6 @@ class ChannelsInfo(object):
         self.rest = HealthchecksioHelper(module)
 
     def get(self):
-        if self.module.check_mode:
-            self.module.exit_json(changed=False, data={})
-
         endpoint = "channels"
 
         response = self.rest.get(endpoint)
@@ -260,9 +254,6 @@ class ChecksFlipsInfo(object):
         self.rest = HealthchecksioHelper(module)
 
     def get(self):
-        if self.module.check_mode:
-            self.module.exit_json(changed=False, data={})
-
         uuid = self.module.params.get("uuid", None)
         endpoint = "checks/{0}/flips".format(uuid)
 
@@ -285,9 +276,6 @@ class ChecksInfo(object):
         self.rest = HealthchecksioHelper(module)
 
     def get(self):
-        if self.module.check_mode:
-            self.module.exit_json(changed=False, data={})
-
         endpoint = "checks"
 
         tags = self.module.params.get("tags", None)
@@ -325,9 +313,6 @@ class ChecksPingsInfo(object):
         self.rest = HealthchecksioHelper(module)
 
     def get(self):
-        if self.module.check_mode:
-            self.module.exit_json(changed=False, data={})
-
         uuid = self.module.params.get("uuid", None)
         endpoint = "checks/{0}/pings".format(uuid)
 


### PR DESCRIPTION
## Summary

Removes `check_mode` early exits that returned empty `data` for read-only info helpers (`BadgesInfo`, `ChannelsInfo`, `ChecksFlipsInfo`, `ChecksInfo`, `ChecksPingsInfo`). These paths only perform GET requests and are safe under `--check`.

**Unchanged:** `checks` create/update/delete/pause and `ping` keep existing check-mode behavior.

Fixes #34.