### PR TITLE
chore: release v1.5.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Community Healthchecks.io Release Notes
 
 .. contents:: Topics
 
+v1.5.1
+======
+
+Bugfixes
+--------
+
+- badges_info, channels_info, checks_flips_info, checks_info, and checks_pings_info perform read-only GET requests in check mode instead of returning empty data (https://github.com/ansible-collections/community.healthchecksio/issues/34).
+
 v1.5.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -109,3 +109,12 @@ releases:
       - checks_info - Add optional ``name`` filter when listing checks; values sent
         to the API are URL-encoded.
     release_date: '2026-04-19'
+  1.5.1:
+    changes:
+      bugfixes:
+      - badges_info, channels_info, checks_flips_info, checks_info, and checks_pings_info
+        perform read-only GET requests in check mode instead of returning empty data
+        (https://github.com/ansible-collections/community.healthchecksio/issues/34).
+    fragments:
+    - 34-info-get-check-mode.yml
+    release_date: '2026-04-20'

--- a/changelogs/fragments/34-info-get-check-mode.yml
+++ b/changelogs/fragments/34-info-get-check-mode.yml
@@ -1,5 +1,0 @@
-bugfixes:
-  - >-
-    badges_info, channels_info, checks_flips_info, checks_info, and checks_pings_info
-    perform read-only GET requests in check mode instead of returning empty data
-    (https://github.com/ansible-collections/community.healthchecksio/issues/34).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: healthchecksio
-version: 1.5.0
+version: 1.5.1
 readme: README.md
 authors:
   - Mark Mercado (https://github.com/mamercad)


### PR DESCRIPTION
## Summary

Prepare collection **v1.5.1** (patch release).

- Bump `galaxy.yml` to **1.5.1**
- Fold changelog fragment for #50 / #34 (info modules read-only GETs in check mode) into `CHANGELOG.rst` and `changelogs/changelog.yaml` via `antsibull-changelog release`

## After merge

Tag `v1.5.1` and publish to Ansible Galaxy per maintainer process.
