### PR TITLE
ci: fix ansible-test workflows and document releases

### DIFF
--- a/.github/workflows/ansible-test-sanity.yml
+++ b/.github/workflows/ansible-test-sanity.yml
@@ -11,18 +11,19 @@ jobs:
   sanity:
     name: Sanity (Ⓐ$${{ matrix.ansible }})
     strategy:
+      fail-fast: false
       matrix:
         include:
           - ansible: stable-2.10
-            python-version: '3.9'
+            origin-python-version: '3.9'
           - ansible: stable-2.11
-            python-version: '3.9'
+            origin-python-version: '3.9'
           - ansible: stable-2.12
-            python-version: '3.9'
+            origin-python-version: '3.9'
           - ansible: stable-2.13
-            python-version: '3.9'
+            origin-python-version: '3.9'
           - ansible: devel
-            python-version: '3.12'
+            origin-python-version: '3.13'
     runs-on: ubuntu-latest
     steps:
       - name: Perform testing
@@ -30,7 +31,7 @@ jobs:
         with:
           ansible-core-version: ${{ matrix.ansible }}
           # pre-test-cmd:
-          python-version: ${{ matrix.python-version }}
+          origin-python-version: ${{ matrix.origin-python-version }}
           # target-python-version:
           testing-type: sanity
           # test-deps:

--- a/.github/workflows/ansible-test-unit.yml
+++ b/.github/workflows/ansible-test-unit.yml
@@ -13,20 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     name: Units (Ⓐ${{ matrix.ansible }})
     strategy:
-      # As soon as the first unit test fails, cancel the others to free up the CI queue
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - ansible: stable-2.10
-            python-version: '3.9'
+            origin-python-version: '3.9'
           - ansible: stable-2.11
-            python-version: '3.9'
+            origin-python-version: '3.9'
           - ansible: stable-2.12
-            python-version: '3.9'
+            origin-python-version: '3.9'
           - ansible: stable-2.13
-            python-version: '3.9'
+            origin-python-version: '3.9'
           - ansible: devel
-            python-version: '3.12'
+            origin-python-version: '3.13'
 
     steps:
       - name: Perform testing
@@ -34,6 +33,6 @@ jobs:
         with:
           ansible-core-version: ${{ matrix.ansible }}
           # pre-test-cmd:
-          python-version: ${{ matrix.python-version }}
+          origin-python-version: ${{ matrix.origin-python-version }}
           # target-python-version:
           testing-type: units

--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ celerybeat.pid
 
 # Environments
 .env
+.envrc
 .venv
 env/
 venv/

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -5,3 +5,14 @@ Refer to the [Maintainer guidelines](https://github.com/ansible/community-docs/b
 ## Changelog
 
 With [uv](https://docs.astral.sh/uv/) installed, run `uv sync --group dev` once, then use `uv run antsibull-changelog …` (for example `uv run antsibull-changelog release --version X.Y.Z`).
+
+## Releases and Ansible Galaxy
+
+See **[RELEASE.md](RELEASE.md)** for the full release checklist, the Zuul re-tag backfill procedure for missing Galaxy versions, tag format rules, and troubleshooting.
+
+Summary:
+
+- **`community.*` collections publish to Galaxy only via Zuul** when a plain **`X.Y.Z`** tag (no `v` prefix) is pushed to upstream.
+- Watch the [Ansible Content CI dashboard](https://ansible.softwarefactory-project.io/zuul/status) after pushing a tag.
+- **Maintainers cannot publish manually** with `ansible-galaxy collection publish` or a repository workflow unless a `community` namespace owner provides infrastructure — that is not available to typical collection maintainers.
+- Missing Galaxy versions caused by `v`-prefixed tags: follow the backfill steps in **RELEASE.md** (delete `v` tag, re-tag as `X.Y.Z`, verify Zuul/Galaxy, then recreate the GitHub release).

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ See [Ansible Using collections](https://docs.ansible.com/ansible/devel/user_guid
 
 ## Release notes
 
-See the [changelog](https://github.com/ansible-collections/REPONAMEHERE/tree/main/CHANGELOG.rst).
+See the [changelog](https://github.com/ansible-collections/community.healthchecksio/blob/main/CHANGELOG.rst).
 
 ## Roadmap
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,109 @@
+# Releasing `community.healthchecksio`
+
+This collection follows the [Ansible community release process for collections without release branches](https://docs.ansible.com/ansible/latest/community/collection_contributors/collection_release_without_branches.html).
+
+## Backfill missing Galaxy versions (issue #52)
+
+Versions **1.3.2**, **1.4.0**, **1.5.0**, and **1.5.1** exist as GitHub tags and releases but were **never published to Ansible Galaxy** because they were tagged with a `v` prefix (`v1.3.2`, …). Zuul only publishes plain **`X.Y.Z`** tags for `community.*` collections.
+
+**Do not** try to backfill with `ansible-galaxy collection publish` or a GitHub Actions workflow. Manual Galaxy publish requires **`community` namespace owner** permissions. Collection maintainers do not have that access ([issue #52](https://github.com/ansible-collections/community.healthchecksio/issues/52)).
+
+The fix is to delete the `v`-prefixed tags, recreate them as plain semver tags at the **same commits**, push, and let Zuul publish.
+
+### Procedure (run oldest to newest)
+
+For each missing version, repeat these steps. Example uses **1.3.2**; substitute the version for 1.4.0, 1.5.0, and 1.5.1.
+
+1. **Record the commit** the existing tag points to (before deleting anything):
+
+   ```bash
+   git fetch origin --tags
+   COMMIT=$(git rev-parse v1.3.2^{commit})
+   echo "${COMMIT}"
+   ```
+
+2. **Delete the `v`-prefixed tag** locally and on GitHub:
+
+   ```bash
+   git tag -d v1.3.2
+   git push origin :refs/tags/v1.3.2
+   ```
+
+3. **Delete the GitHub Release** for `v1.3.2` (Releases → delete). Zuul does not need the release; recreating it prematurely confuses users when Galaxy still lacks the version.
+
+4. **Create and push a plain tag** at the same commit:
+
+   ```bash
+   git tag -a 1.3.2 "${COMMIT}" -m "community.healthchecksio: 1.3.2"
+   git push origin 1.3.2
+   ```
+
+5. **Watch Zuul** until the release job succeeds:
+
+   - [Ansible Content CI dashboard](https://ansible.softwarefactory-project.io/zuul/status) — filter for `community.healthchecksio`.
+
+6. **Verify Galaxy** lists the version:
+
+   ```bash
+   curl -sS 'https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/community/healthchecksio/versions/' \
+     | python3 -c "import sys,json; print([v['version'] for v in json.load(sys.stdin)['data']])"
+   ```
+
+   Or install it:
+
+   ```bash
+   ansible-galaxy collection install 'community.healthchecksio:==1.3.2'
+   ```
+
+7. **Recreate the GitHub Release** only after Galaxy confirms the version (tag `1.3.2`, title `1.3.2`, body pointing at [CHANGELOG.rst](CHANGELOG.rst)).
+
+8. Proceed to the next version (**1.4.0** → **1.5.0** → **1.5.1**).
+
+### If Zuul fails three times
+
+Delete the plain tag and push it again at the same commit (Zuul retry guidance from Ansible community infra):
+
+```bash
+git push origin :refs/tags/1.3.2
+git tag -a 1.3.2 "${COMMIT}" -m "community.healthchecksio: 1.3.2"
+git push origin 1.3.2
+```
+
+If failures persist, ask in Matrix `#community` (for example `@gundalow` or `@felixfontein`).
+
+## Tag format (required)
+
+Official `community.*` collections are published to Galaxy **only** by **Zuul** when a tag is pushed to the upstream repository.
+
+| Tag format | Zuul publishes to Galaxy? |
+|------------|---------------------------|
+| `X.Y.Z` (for example `1.5.2`) | Yes |
+| `vX.Y.Z` (for example `v1.5.2`) | **No** |
+
+Use annotated tags (`git tag -a`). See [upstream docs](https://docs.ansible.com/ansible/latest/community/collection_contributors/collection_release_without_branches.html#publish-the-collection).
+
+Older releases in this repo mixed both styles (`1.3.1` vs `v1.4.0`). All **new** releases must use plain semver.
+
+## Why manual publish and GitHub Actions do not work here
+
+- **`ansible-galaxy collection publish`** for `community.healthchecksio` requires a Galaxy API token whose owner has **`galaxy.collection_namespace_owner_namespace`** on the shared [`community` namespace](https://galaxy.ansible.com/ui/namespaces/community/). Repository maintainers are not automatically namespace owners.
+- **Repository GitHub Actions** cannot substitute for Zuul unless someone with namespace-owner credentials adds a `GALAXY_API_KEY` secret — that is infrastructure-owned, not a maintainer self-service path.
+
+Coordinate with Ansible community infrastructure in `#community` if Zuul itself is broken; do not add collection-local publish workflows that imply maintainers can publish directly.
+
+## Standard release checklist
+
+For each **new** release after backfill is complete:
+
+1. Announce the release in the collection pinboard / Matrix `#community` channel.
+2. Bump `galaxy.yml` `version` and generate the changelog (`uv run antsibull-changelog release --version X.Y.Z`).
+3. Merge the release PR to `main`.
+4. Tag the release commit as **`X.Y.Z`** (no `v` prefix) and push to `origin` (`ansible-collections/community.healthchecksio`).
+5. Watch [Zuul](https://ansible.softwarefactory-project.io/zuul/status) and confirm the version appears on [Ansible Galaxy](https://galaxy.ansible.com/ui/repo/published/community/healthchecksio/).
+6. Create a GitHub Release from the tag (title = version, body links to [CHANGELOG.rst](CHANGELOG.rst)).
+7. Bump `galaxy.yml` on `main` to the next development version.
+
+## After publishing
+
+- Confirm install works: `ansible-galaxy collection install 'community.healthchecksio:==X.Y.Z'`
+- Announce in `#social` on Matrix (mention `@newsbot` for the Bullhorn newsletter).


### PR DESCRIPTION
## Summary

- **CI workflow fixes** for `ansible-test-sanity` and `ansible-test-unit`:
  - Rename matrix `python-version` → `origin-python-version` to match the current `ansible/ansible-test` action input (the old key was ignored, so devel ran on the action default instead of the intended interpreter).
  - Bump **devel** matrix leg to **Python 3.13** (ansible-core devel targets 3.13+).
  - Set **`fail-fast: false`** on both matrices so one failing leg does not cancel the rest (unit workflow previously used `fail-fast: true`).

- **Maintainer documentation** bundled with the CI fix:
  - Add **`RELEASE.md`** — Galaxy/Zuul release checklist, tag format rules (`X.Y.Z` vs `vX.Y.Z`), and backfill procedure for versions missed due to `v`-prefixed tags (issue #52).
  - Extend **`MAINTAINING.md`** with a short releases section linking to `RELEASE.md`.
  - Fix **`README.md`** changelog link (replace `REPONAMEHERE` placeholder with this repo).
  - Ignore **`.envrc`** in **`.gitignore`** so local direnv files are not committed accidentally.

## Root cause

The `ansible/ansible-test` GitHub Action renamed/standardized on `origin-python-version` for the controller Python used when building the test environment. Our workflows still passed `python-version`, which the action no longer reads, so matrix Python selection (especially devel on 3.12/3.13) was not applied.

## Test plan

- [ ] CI sanity and unit workflows run on this PR
- [ ] All matrix legs (stable-2.10 through devel) complete independently with `fail-fast: false`
- [ ] devel leg uses Python 3.13 per workflow matrix


Made with [Cursor](https://cursor.com)