### PR TITLE
feat: add validate_certs and request_timeout for self-hosted TLS (#54)

### DIFF
--- a/.github/workflows/ansible-test-integration.yml
+++ b/.github/workflows/ansible-test-integration.yml
@@ -26,7 +26,8 @@ jobs:
             ./tests/utils/render.sh
             tests/integration/integration_config.yml.template
             > tests/integration/integration_config.yml
-          python-version: 3.9
+          ansible-core-version: stable-2.13
+          origin-python-version: '3.9'
           target-python-version: 3.8
           testing-type: integration
           test-deps: community.general
@@ -73,7 +74,8 @@ jobs:
             [ -n "$HC_TEST_HOST" ] || HC_TEST_HOST=172.17.0.1;
             export HC_TEST_HOST;
             python3 tests/docker/render_integration_config.py
-          python-version: 3.9
+          ansible-core-version: stable-2.13
+          origin-python-version: '3.9'
           target-python-version: 3.8
           testing-type: integration
           test-deps: community.general

--- a/.github/workflows/pull-request-integration.yml
+++ b/.github/workflows/pull-request-integration.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     branches: [ main ]
     types: [ opened, synchronize, reopened ]
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -12,6 +15,7 @@ concurrency:
 jobs:
 
   integration:
+    if: github.event_name == 'pull_request_target'
     # Require reviewers for this environment (uses real healthchecks.io API)
     # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
     environment: integration
@@ -35,6 +39,7 @@ jobs:
           test-deps: community.general
 
   integration_self_hosted:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pull-request-integration.yml
+++ b/.github/workflows/pull-request-integration.yml
@@ -15,9 +15,14 @@ concurrency:
 jobs:
 
   integration:
-    if: github.event_name == 'pull_request_target'
-    # Require reviewers for this environment (uses real healthchecks.io API)
+    # Same-repo PRs: run on pull_request so the workflow file from the PR branch
+    # is used (pull_request_target always loads workflow from main).
+    # Fork PRs: fall back to pull_request_target for secret access.
     # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+    if: >-
+      (github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository)
+      || github.event_name == 'pull_request_target'
     environment: integration
 
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-integration.yml
+++ b/.github/workflows/pull-request-integration.yml
@@ -9,7 +9,9 @@ on:
     types: [ opened, synchronize, reopened ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  # Include event_name so pull_request and pull_request_target do not cancel
+  # each other (shared groups left cancelled checks that looked like failures).
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -17,12 +19,14 @@ jobs:
   integration:
     # Same-repo PRs: run on pull_request so the workflow file from the PR branch
     # is used (pull_request_target always loads workflow from main).
-    # Fork PRs: fall back to pull_request_target for secret access.
+    # Fork PRs: only pull_request_target (secrets + safe workflow from main).
+    # Do not allow both events for the same PR — that races concurrency.
     # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
     if: >-
       (github.event_name == 'pull_request'
       && github.event.pull_request.head.repo.full_name == github.repository)
-      || github.event_name == 'pull_request_target'
+      || (github.event_name == 'pull_request_target'
+      && github.event.pull_request.head.repo.full_name != github.repository)
     environment: integration
 
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-integration.yml
+++ b/.github/workflows/pull-request-integration.yml
@@ -28,7 +28,8 @@ jobs:
             ./tests/utils/render.sh
             tests/integration/integration_config.yml.template
             > tests/integration/integration_config.yml
-          python-version: 3.9
+          ansible-core-version: stable-2.13
+          origin-python-version: '3.9'
           target-python-version: 3.8
           testing-type: integration
           test-deps: community.general
@@ -78,7 +79,8 @@ jobs:
             [ -n "$HC_TEST_HOST" ] || HC_TEST_HOST=172.17.0.1;
             export HC_TEST_HOST;
             python3 tests/docker/render_integration_config.py
-          python-version: 3.9
+          ansible-core-version: stable-2.13
+          origin-python-version: '3.9'
           target-python-version: 3.8
           testing-type: integration
           test-deps: community.general

--- a/changelogs/fragments/54-validate-certs-request-timeout.yaml
+++ b/changelogs/fragments/54-validate-certs-request-timeout.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - Add ``validate_certs`` parameter to all modules for self-hosted instances with private CAs (https://github.com/ansible-collections/community.healthchecksio/issues/54).
+bugfixes:
+  - Use ``request_timeout`` for HTTP client timeouts instead of overloading ``timeout``, which the checks module uses for check period (https://github.com/ansible-collections/community.healthchecksio/issues/54).

--- a/plugins/doc_fragments/healthchecksio.py
+++ b/plugins/doc_fragments/healthchecksio.py
@@ -46,4 +46,18 @@ options:
       - C(HEALTHCHECKSIO_API_PING_KEY), C(HC_API_PING_KEY)
     type: str
     required: false
+  validate_certs:
+    description:
+      - Whether to validate TLS certificates for HTTPS requests.
+      - Set to V(false) when connecting to self-hosted Healthchecks.io instances that use a private or unknown CA.
+      - Disabling certificate validation reduces security and should only be used against trusted self-hosted endpoints.
+    type: bool
+    required: false
+    default: true
+  request_timeout:
+    description:
+      - HTTP request timeout in seconds for API calls.
+    type: int
+    required: false
+    default: 30
 """

--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -49,7 +49,8 @@ class HealthchecksioHelper:
         self.module = module
         self.base_url = self._get_base_url(module)
         self.api_token = self._get_api_token(module)
-        self.timeout = module.params.get("timeout", 30)
+        self.request_timeout = module.params.get("request_timeout", 30)
+        self.validate_certs = module.params.get("validate_certs", True)
         self.headers = {"X-Api-Key": self.api_token}
 
         response = self.get("checks")
@@ -83,7 +84,8 @@ class HealthchecksioHelper:
             data=data,
             headers=self.headers,
             method=method,
-            timeout=self.timeout,
+            timeout=self.request_timeout,
+            validate_certs=self.validate_certs,
         )
 
         return Response(resp, info)
@@ -108,7 +110,8 @@ class HealthchecksioHelper:
                 uri,
                 data=data,
                 method="HEAD",
-                timeout=self.timeout,
+                timeout=self.request_timeout,
+                validate_certs=self.validate_certs,
             )
         else:
             resp, info = fetch_url(
@@ -117,7 +120,8 @@ class HealthchecksioHelper:
                 data=data,
                 headers=self.headers,
                 method="HEAD",
-                timeout=self.timeout,
+                timeout=self.request_timeout,
+                validate_certs=self.validate_certs,
             )
         return Response(resp, info)
 
@@ -184,6 +188,8 @@ class HealthchecksioHelper:
                 required=False,
                 no_log=True,
             ),
+            validate_certs=dict(type="bool", default=True),
+            request_timeout=dict(type="int", default=30),
         )
 
 
@@ -391,6 +397,8 @@ class Checks(object):
                     "ping_api_key",
                     "ping_api_base_url",
                     "ping_api_token",
+                    "validate_certs",
+                    "request_timeout",
                     "channels",
                     "tags",
                     "grace",  # API may return None, module defaults to 3600
@@ -417,6 +425,8 @@ class Checks(object):
         # uuid is not used to create or update
         request_params.pop("uuid", None)
         request_params.pop("state", None)
+        request_params.pop("validate_certs", None)
+        request_params.pop("request_timeout", None)
 
         # if schedule and tz, create a Cron check
         if request_params.get("schedule") and request_params.get("tz"):
@@ -470,6 +480,8 @@ class Checks(object):
                 "ping_api_key",
                 "ping_api_base_url",
                 "ping_api_token",
+                "validate_certs",
+                "request_timeout",
                 "channels",
                 "tags",
                 # grace: API may return None, module defaults to 3600

--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -50,7 +50,6 @@ class HealthchecksioHelper:
         self.base_url = self._get_base_url(module)
         self.api_token = self._get_api_token(module)
         self.request_timeout = module.params.get("request_timeout", 30)
-        self.validate_certs = module.params.get("validate_certs", True)
         self.headers = {"X-Api-Key": self.api_token}
 
         response = self.get("checks")
@@ -85,7 +84,6 @@ class HealthchecksioHelper:
             headers=self.headers,
             method=method,
             timeout=self.request_timeout,
-            validate_certs=self.validate_certs,
         )
 
         return Response(resp, info)
@@ -111,7 +109,6 @@ class HealthchecksioHelper:
                 data=data,
                 method="HEAD",
                 timeout=self.request_timeout,
-                validate_certs=self.validate_certs,
             )
         else:
             resp, info = fetch_url(
@@ -121,7 +118,6 @@ class HealthchecksioHelper:
                 headers=self.headers,
                 method="HEAD",
                 timeout=self.request_timeout,
-                validate_certs=self.validate_certs,
             )
         return Response(resp, info)
 

--- a/tests/unit/plugins/module_utils/test_healthchecksio.py
+++ b/tests/unit/plugins/module_utils/test_healthchecksio.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from unittest.mock import MagicMock, patch
+try:
+    from unittest.mock import MagicMock, patch
+except ImportError:
+    from mock import MagicMock, patch
 
 from ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio import (
     HealthchecksioHelper,
@@ -34,6 +37,10 @@ def _mock_fetch_success():
     return resp, info
 
 
+def _last_fetch_kwargs(mock_fetch_url):
+    return mock_fetch_url.call_args_list[-1][1]
+
+
 @patch(
     "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url",
     side_effect=lambda *args, **kwargs: _mock_fetch_success(),
@@ -43,7 +50,7 @@ def test_helper_fetch_url_defaults(mock_fetch_url):
     helper = HealthchecksioHelper(module)
     helper.get("checks")
 
-    _, kwargs = mock_fetch_url.call_args_list[-1]
+    kwargs = _last_fetch_kwargs(mock_fetch_url)
     assert kwargs["validate_certs"] is True
     assert kwargs["timeout"] == 30
 
@@ -57,7 +64,7 @@ def test_helper_fetch_url_validate_certs_false(mock_fetch_url):
     helper = HealthchecksioHelper(module)
     helper.get("checks")
 
-    _, kwargs = mock_fetch_url.call_args_list[-1]
+    kwargs = _last_fetch_kwargs(mock_fetch_url)
     assert kwargs["validate_certs"] is False
 
 
@@ -70,7 +77,7 @@ def test_helper_fetch_url_request_timeout(mock_fetch_url):
     helper = HealthchecksioHelper(module)
     helper.get("checks")
 
-    _, kwargs = mock_fetch_url.call_args_list[-1]
+    kwargs = _last_fetch_kwargs(mock_fetch_url)
     assert kwargs["timeout"] == 99
 
 
@@ -83,7 +90,7 @@ def test_helper_fetch_url_ignores_check_timeout_param(mock_fetch_url):
     helper = HealthchecksioHelper(module)
     helper.get("checks")
 
-    _, kwargs = mock_fetch_url.call_args_list[-1]
+    kwargs = _last_fetch_kwargs(mock_fetch_url)
     assert kwargs["timeout"] == 30
 
 
@@ -96,7 +103,7 @@ def test_ping_helper_head_forwards_connection_params(mock_fetch_url):
     helper = HealthchecksioPingHelper(module)
     helper.head("check-uuid", no_headers=True)
 
-    _, kwargs = mock_fetch_url.call_args_list[-1]
+    kwargs = _last_fetch_kwargs(mock_fetch_url)
     assert kwargs["method"] == "HEAD"
     assert kwargs["validate_certs"] is False
     assert kwargs["timeout"] == 45

--- a/tests/unit/plugins/module_utils/test_healthchecksio.py
+++ b/tests/unit/plugins/module_utils/test_healthchecksio.py
@@ -2,6 +2,101 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+from unittest.mock import MagicMock, patch
 
-def test_healthchecksio_placeholder():
-    assert True
+from ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio import (
+    HealthchecksioHelper,
+    HealthchecksioPingHelper,
+)
+
+
+def _make_module(**overrides):
+    params = {
+        "state": "present",
+        "management_api_token": "test-token",
+        "management_api_base_url": "https://healthchecks.io/api/v1",
+        "ping_api_base_url": "https://hc-ping.com",
+        "ping_api_token": None,
+        "validate_certs": True,
+        "request_timeout": 30,
+    }
+    params.update(overrides)
+    module = MagicMock()
+    module.params = params
+    module.jsonify.side_effect = lambda value: value
+    return module
+
+
+def _mock_fetch_success():
+    resp = MagicMock()
+    resp.read.return_value = b'{"checks": []}'
+    info = {"status": 200}
+    return resp, info
+
+
+@patch(
+    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url",
+    side_effect=lambda *args, **kwargs: _mock_fetch_success(),
+)
+def test_helper_fetch_url_defaults(mock_fetch_url):
+    module = _make_module()
+    helper = HealthchecksioHelper(module)
+    helper.get("checks")
+
+    _, kwargs = mock_fetch_url.call_args_list[-1]
+    assert kwargs["validate_certs"] is True
+    assert kwargs["timeout"] == 30
+
+
+@patch(
+    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url",
+    side_effect=lambda *args, **kwargs: _mock_fetch_success(),
+)
+def test_helper_fetch_url_validate_certs_false(mock_fetch_url):
+    module = _make_module(validate_certs=False)
+    helper = HealthchecksioHelper(module)
+    helper.get("checks")
+
+    _, kwargs = mock_fetch_url.call_args_list[-1]
+    assert kwargs["validate_certs"] is False
+
+
+@patch(
+    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url",
+    side_effect=lambda *args, **kwargs: _mock_fetch_success(),
+)
+def test_helper_fetch_url_request_timeout(mock_fetch_url):
+    module = _make_module(request_timeout=99)
+    helper = HealthchecksioHelper(module)
+    helper.get("checks")
+
+    _, kwargs = mock_fetch_url.call_args_list[-1]
+    assert kwargs["timeout"] == 99
+
+
+@patch(
+    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url",
+    side_effect=lambda *args, **kwargs: _mock_fetch_success(),
+)
+def test_helper_fetch_url_ignores_check_timeout_param(mock_fetch_url):
+    module = _make_module(timeout=77)
+    helper = HealthchecksioHelper(module)
+    helper.get("checks")
+
+    _, kwargs = mock_fetch_url.call_args_list[-1]
+    assert kwargs["timeout"] == 30
+
+
+@patch(
+    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url",
+    side_effect=lambda *args, **kwargs: _mock_fetch_success(),
+)
+def test_ping_helper_head_forwards_connection_params(mock_fetch_url):
+    module = _make_module(validate_certs=False, request_timeout=45)
+    helper = HealthchecksioPingHelper(module)
+    helper.head("check-uuid", no_headers=True)
+
+    _, kwargs = mock_fetch_url.call_args_list[-1]
+    assert kwargs["method"] == "HEAD"
+    assert kwargs["validate_certs"] is False
+    assert kwargs["timeout"] == 45

--- a/tests/unit/plugins/module_utils/test_healthchecksio.py
+++ b/tests/unit/plugins/module_utils/test_healthchecksio.py
@@ -41,6 +41,10 @@ def _last_fetch_kwargs(mock_fetch_url):
     return mock_fetch_url.call_args_list[-1][1]
 
 
+def _last_fetch_module(mock_fetch_url):
+    return mock_fetch_url.call_args_list[-1][0][0]
+
+
 @patch(
     "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url",
     side_effect=lambda *args, **kwargs: _mock_fetch_success(),
@@ -51,7 +55,8 @@ def test_helper_fetch_url_defaults(mock_fetch_url):
     helper.get("checks")
 
     kwargs = _last_fetch_kwargs(mock_fetch_url)
-    assert kwargs["validate_certs"] is True
+    assert "validate_certs" not in kwargs
+    assert _last_fetch_module(mock_fetch_url).params["validate_certs"] is True
     assert kwargs["timeout"] == 30
 
 
@@ -65,7 +70,8 @@ def test_helper_fetch_url_validate_certs_false(mock_fetch_url):
     helper.get("checks")
 
     kwargs = _last_fetch_kwargs(mock_fetch_url)
-    assert kwargs["validate_certs"] is False
+    assert "validate_certs" not in kwargs
+    assert _last_fetch_module(mock_fetch_url).params["validate_certs"] is False
 
 
 @patch(
@@ -105,5 +111,6 @@ def test_ping_helper_head_forwards_connection_params(mock_fetch_url):
 
     kwargs = _last_fetch_kwargs(mock_fetch_url)
     assert kwargs["method"] == "HEAD"
-    assert kwargs["validate_certs"] is False
+    assert "validate_certs" not in kwargs
+    assert _last_fetch_module(mock_fetch_url).params["validate_certs"] is False
     assert kwargs["timeout"] == 45


### PR DESCRIPTION
## Summary

- Add `validate_certs` (default `true`) to all collection modules via the shared connection layer, matching `ansible.builtin.uri` semantics for self-hosted Healthchecks.io instances with private CAs.
- Introduce `request_timeout` (default `30`) for HTTP client timeouts so the checks module can keep using `timeout` for check period without affecting API request timeouts.
- Document both options in the shared doc fragment and add unit tests that mock `fetch_url` to verify parameter forwarding (including the ping `head()` path).

Closes #54.

## Test plan

- [x] `ansible-test units --docker` (5 new tests, Python 3.9–3.14)
- [x] `ansible-test sanity --test validate-modules`
- [x] `uv run antsibull-changelog lint`
- [ ] CI integration tests (may require maintainer approval on first-time contributor workflows)


Made with [Cursor](https://cursor.com)