### PR TITLE
chore: release 1.5.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Community Healthchecks.io Release Notes
 
 .. contents:: Topics
 
+v1.5.2
+======
+
+Minor Changes
+-------------
+
+- Add ``validate_certs`` parameter to all modules for self-hosted instances with private CAs (https://github.com/ansible-collections/community.healthchecksio/issues/54).
+
+Bugfixes
+--------
+
+- Use ``request_timeout`` for HTTP client timeouts instead of overloading ``timeout``, which the checks module uses for check period (https://github.com/ansible-collections/community.healthchecksio/issues/54).
+
 v1.5.1
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -118,3 +118,14 @@ releases:
     fragments:
     - 34-info-get-check-mode.yml
     release_date: '2026-04-20'
+  1.5.2:
+    changes:
+      bugfixes:
+      - Use ``request_timeout`` for HTTP client timeouts instead of overloading ``timeout``,
+        which the checks module uses for check period (https://github.com/ansible-collections/community.healthchecksio/issues/54).
+      minor_changes:
+      - Add ``validate_certs`` parameter to all modules for self-hosted instances
+        with private CAs (https://github.com/ansible-collections/community.healthchecksio/issues/54).
+    fragments:
+    - 54-validate-certs-request-timeout.yaml
+    release_date: '2026-07-16'

--- a/changelogs/fragments/54-validate-certs-request-timeout.yaml
+++ b/changelogs/fragments/54-validate-certs-request-timeout.yaml
@@ -1,4 +1,0 @@
-minor_changes:
-  - Add ``validate_certs`` parameter to all modules for self-hosted instances with private CAs (https://github.com/ansible-collections/community.healthchecksio/issues/54).
-bugfixes:
-  - Use ``request_timeout`` for HTTP client timeouts instead of overloading ``timeout``, which the checks module uses for check period (https://github.com/ansible-collections/community.healthchecksio/issues/54).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: healthchecksio
-version: 1.5.2-dev0
+version: 1.5.2
 readme: README.md
 authors:
   - Mark Mercado (https://github.com/mamercad)


### PR DESCRIPTION
## Summary
- Prepare collection **1.5.2** (minor release for #54).
- Bump `galaxy.yml` to **1.5.2**.
- Fold changelog fragment for `validate_certs` / `request_timeout` into `CHANGELOG.rst` and `changelogs/changelog.yaml` via `antsibull-changelog release`.

## After merge
1. Tag plain **`1.5.2`** (no `v` prefix) on the release commit and push to `origin`.
2. Watch [Zuul](https://ansible.softwarefactory-project.io/zuul/status) until Galaxy publish succeeds.
3. Create GitHub Release from tag `1.5.2` (title = `1.5.2`).
4. Bump `galaxy.yml` on `main` to `1.5.3-dev0`.

See `RELEASE.md`.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: Galaxy lists `1.5.2`
- [ ] `ansible-galaxy collection install 'community.healthchecksio:==1.5.2'`

Made with [Cursor](https://cursor.com)