### PR TITLE
chore: bump development version to 1.5.3-dev0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: healthchecksio
-version: 1.5.2
+version: 1.5.3-dev0
 readme: README.md
 authors:
   - Mark Mercado (https://github.com/mamercad)


### PR DESCRIPTION
## Summary
- Bump `galaxy.yml` to `1.5.3-dev0` after publishing **1.5.2** to Galaxy.

## Test plan
- [ ] CI green

Made with [Cursor](https://cursor.com)