### PR TITLE
feat: add run ID support to ping module

### DIFF
--- a/changelogs/fragments/58-ping-runid.yml
+++ b/changelogs/fragments/58-ping-runid.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ping - add ``runid`` parameter support for Healthchecks.io run ID tracking (https://github.com/ansible-collections/community.healthchecksio/issues/58).

--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -602,7 +602,7 @@ class Ping(object):
         self.module = module
         self.rest = HealthchecksioPingHelper(module)
 
-    def create(self, uuid, signal):
+    def create(self, uuid, signal, runid=None):
         if self.module.check_mode:
             self.module.exit_json(changed=False, data={})
 
@@ -610,6 +610,9 @@ class Ping(object):
             endpoint = "{0}".format(uuid)
         else:
             endpoint = "{0}/{1}".format(uuid, signal)
+
+        if runid is not None:
+            endpoint = "{0}?rid={1}".format(endpoint, quote(runid, safe=""))
 
         response = self.rest.head(endpoint, no_headers=True)
         status_code = response.status_code

--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -611,10 +611,13 @@ class Ping(object):
         else:
             endpoint = "{0}/{1}".format(uuid, signal)
 
+        request_endpoint = endpoint
         if runid is not None:
-            endpoint = "{0}?rid={1}".format(endpoint, quote(runid, safe=""))
+            request_endpoint = "{0}?rid={1}".format(
+                request_endpoint, quote(runid, safe="")
+            )
 
-        response = self.rest.head(endpoint, no_headers=True)
+        response = self.rest.head(request_endpoint, no_headers=True)
         status_code = response.status_code
 
         if status_code == 200:

--- a/plugins/modules/ping.py
+++ b/plugins/modules/ping.py
@@ -34,6 +34,12 @@ options:
     type: str
     choices: ["success", "fail", "start"]
     default: success
+  runid:
+    description:
+      - Optional run ID to send in the Healthchecks.io C(rid) query parameter.
+      - Use the same run ID for matching C(start), C(success), and C(fail) pings from one job execution.
+      - Healthchecks.io requires this value to be a UUID in canonical textual representation.
+    type: str
 extends_documentation_fragment:
   - community.healthchecksio.healthchecksio.documentation
 """
@@ -56,6 +62,13 @@ EXAMPLES = r"""
     state: present
     uuid: "{{ check_uuid }}"
     signal: start
+
+- name: Send a start signal with a run ID
+  community.healthchecksio.ping:
+    state: present
+    uuid: "{{ check_uuid }}"
+    signal: start
+    runid: "{{ ansible_date_time.iso8601_micro | to_uuid }}"
 """
 
 RETURN = r"""
@@ -77,9 +90,10 @@ def run(module):
     state = module.params.pop("state")
     uuid = module.params.pop("uuid")
     signal = module.params.pop("signal")
+    runid = module.params.pop("runid")
     ping = Ping(module)
     if state == "present":
-        ping.create(uuid, signal)
+        ping.create(uuid, signal, runid)
 
 
 def main():
@@ -93,6 +107,7 @@ def main():
             required=False,
             default="success",
         ),
+        runid=dict(type="str", required=False),
     )
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 

--- a/tests/integration/targets/ping/tasks/main.yml
+++ b/tests/integration/targets/ping/tasks/main.yml
@@ -8,16 +8,24 @@
         - api_key is not defined
         - api_key | length == 0
 
-    - name: Create a Simple check named "simple test"
+    - name: Generate an invocation-unique run ID
+      ansible.builtin.set_fact:
+        runid: "{{ ansible_date_time.iso8601_micro | to_uuid }}"
+
+    - name: Create an invocation-unique Simple check
       community.healthchecksio.checks:
         state: present
         api_key: "{{ api_key }}"
         management_api_base_url: "{{ management_api_base_url }}"
         ping_api_base_url: "{{ ping_api_base_url }}"
-        name: simple test
+        name: "simple test {{ runid }}"
         unique: ["name"]
         timeout: 77
       register: result
+
+    - name: Set a fact for the check
+      ansible.builtin.set_fact:
+        uuid: "{{ result.uuid }}"
 
     - name: Verify integrations
       ansible.builtin.assert:
@@ -25,12 +33,8 @@
           - result.changed
           - result.data is defined
           - result.data.name is defined
-          - result.data.name == "simple test"
+          - "result.data.name == 'simple test ' + runid"
           - result.uuid is defined
-
-    - name: Set a fact for the check
-      ansible.builtin.set_fact:
-        uuid: "{{ result.uuid }}"
 
     - name: Pause for ten seconds
       ansible.builtin.pause:
@@ -90,6 +94,71 @@
           - result.msg is defined
           - "result.msg == 'Sent success signal to ' + uuid"
 
+    - name: Send start signal with a run ID
+      community.healthchecksio.ping:
+        state: present
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        uuid: "{{ uuid }}"
+        signal: start
+        runid: "{{ runid }}"
+      register: result
+
+    - name: Verify start signal with a run ID
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.msg is defined
+          - "result.msg == 'Sent start signal to ' + uuid + '/start'"
+
+    - name: Send success signal with the same run ID
+      community.healthchecksio.ping:
+        state: present
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        uuid: "{{ uuid }}"
+        signal: success
+        runid: "{{ runid }}"
+      register: result
+
+    - name: Verify success signal with a run ID
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.msg is defined
+          - "result.msg == 'Sent success signal to ' + uuid"
+
+    - name: Get ping history for the run ID
+      community.healthchecksio.checks_pings_info:
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        uuid: "{{ uuid }}"
+      register: ping_history
+      until:
+        - ping_history.data is defined
+        - ping_history.data.pings is defined
+        - ping_history.data.pings | length >= 2
+        - ping_history.data.pings[0].rid is defined
+        - ping_history.data.pings[0].rid == runid
+        - ping_history.data.pings[1].rid is defined
+        - ping_history.data.pings[1].rid == runid
+      retries: 5
+      delay: 2
+
+    - name: Verify the run ID links the start and success signals
+      ansible.builtin.assert:
+        that:
+          - not ping_history.changed
+          - ping_history.data.pings[0].type == "success"
+          - ping_history.data.pings[0].rid == runid
+          - ping_history.data.pings[1].type == "start"
+          - ping_history.data.pings[1].rid == runid
+          - ping_history.data.pings[0].duration is number
+
+  always:
     - name: Delete the Simple check
       community.healthchecksio.checks:
         state: absent
@@ -97,4 +166,4 @@
         management_api_base_url: "{{ management_api_base_url }}"
         ping_api_base_url: "{{ ping_api_base_url }}"
         uuid: "{{ uuid }}"
-      register: result
+      when: uuid is defined

--- a/tests/unit/plugins/modules/test_ping.py
+++ b/tests/unit/plugins/modules/test_ping.py
@@ -2,6 +2,86 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+try:
+    from unittest.mock import MagicMock, patch
+except ImportError:
+    from mock import MagicMock, patch
 
-def test_ping_placeholder():
-    assert True
+from ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio import (
+    Ping,
+)
+from ansible_collections.community.healthchecksio.plugins.modules import ping as ping_module
+
+
+class ExitJson(Exception):
+    pass
+
+
+def _make_module(**overrides):
+    params = {
+        "management_api_token": "test-token",
+        "management_api_base_url": "https://healthchecks.io/api/v1",
+        "ping_api_base_url": "https://hc-ping.com",
+        "ping_api_token": None,
+        "validate_certs": True,
+        "request_timeout": 30,
+    }
+    params.update(overrides)
+    module = MagicMock()
+    module.params = params
+    module.check_mode = False
+    module.jsonify.side_effect = lambda value: value
+    module.exit_json.side_effect = ExitJson
+    return module
+
+
+def _mock_fetch_success():
+    resp = MagicMock()
+    resp.read.return_value = b'{"checks": []}'
+    info = {"status": 200}
+    return resp, info
+
+
+def _last_fetch_url(mock_fetch_url):
+    return mock_fetch_url.call_args_list[-1][0][1]
+
+
+@patch(
+    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url",
+    side_effect=lambda *args, **kwargs: _mock_fetch_success(),
+)
+def test_ping_create_appends_runid_as_rid_query_param(mock_fetch_url):
+    module = _make_module()
+    ping = Ping(module)
+
+    try:
+        ping.create(
+            "check-uuid",
+            "start",
+            "728b3763-ea80-4113-9fc0-f49b3adf226a",
+        )
+    except ExitJson:
+        pass
+
+    assert (
+        _last_fetch_url(mock_fetch_url)
+        == "https://hc-ping.com/check-uuid/start?rid=728b3763-ea80-4113-9fc0-f49b3adf226a"
+    )
+
+
+def test_run_passes_runid_to_ping():
+    module = _make_module(
+        state="present",
+        uuid="check-uuid",
+        signal="success",
+        runid="728b3763-ea80-4113-9fc0-f49b3adf226a",
+    )
+
+    with patch.object(ping_module, "Ping") as ping_cls:
+        ping_module.run(module)
+
+    ping_cls.return_value.create.assert_called_once_with(
+        "check-uuid",
+        "success",
+        "728b3763-ea80-4113-9fc0-f49b3adf226a",
+    )

--- a/tests/unit/plugins/modules/test_ping.py
+++ b/tests/unit/plugins/modules/test_ping.py
@@ -10,7 +10,9 @@ except ImportError:
 from ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio import (
     Ping,
 )
-from ansible_collections.community.healthchecksio.plugins.modules import ping as ping_module
+from ansible_collections.community.healthchecksio.plugins.modules import (
+    ping as ping_module,
+)
 
 
 class ExitJson(Exception):
@@ -66,6 +68,10 @@ def test_ping_create_appends_runid_as_rid_query_param(mock_fetch_url):
     assert (
         _last_fetch_url(mock_fetch_url)
         == "https://hc-ping.com/check-uuid/start?rid=728b3763-ea80-4113-9fc0-f49b3adf226a"
+    )
+    module.exit_json.assert_called_once_with(
+        changed=True,
+        msg="Sent start signal to check-uuid/start",
     )
 
 


### PR DESCRIPTION
## Summary

The ping module can now send Healthchecks.io run IDs so matching start, success, and fail pings can be associated with one job execution.

This adds a runid parameter, appends it as the rid query parameter on ping URLs, documents the option, and covers both endpoint construction and module wiring with unit tests.

## Testing

- ansible-test units --venv --requirements --python 3.12
- ansible-test sanity --venv --requirements --python 3.12

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)