### PR TITLE
chore: prepare 1.5.3 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Community Healthchecks.io Release Notes
 
 .. contents:: Topics
 
+v1.5.3
+======
+
+Minor Changes
+-------------
+
+- ping - add ``runid`` parameter support for Healthchecks.io run ID tracking (https://github.com/ansible-collections/community.healthchecksio/issues/58).
+
 v1.5.2
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -129,3 +129,11 @@ releases:
     fragments:
     - 54-validate-certs-request-timeout.yaml
     release_date: '2026-07-16'
+  1.5.3:
+    changes:
+      minor_changes:
+      - ping - add ``runid`` parameter support for Healthchecks.io run ID tracking
+        (https://github.com/ansible-collections/community.healthchecksio/issues/58).
+    fragments:
+    - 58-ping-runid.yml
+    release_date: '2026-07-31'

--- a/changelogs/fragments/58-ping-runid.yml
+++ b/changelogs/fragments/58-ping-runid.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - ping - add ``runid`` parameter support for Healthchecks.io run ID tracking (https://github.com/ansible-collections/community.healthchecksio/issues/58).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: healthchecksio
-version: 1.5.3-dev0
+version: 1.5.3
 readme: README.md
 authors:
   - Mark Mercado (https://github.com/mamercad)


### PR DESCRIPTION
## Summary

- set the Galaxy collection version to 1.5.3
- consolidate the run ID changelog fragment into the release metadata
- regenerate CHANGELOG.rst for the 1.5.3 release

## Validation

- `antsibull-changelog lint`
- `antsibull-changelog lint-changelog-yaml --strict changelogs/changelog.yaml`
- clean `ansible-galaxy collection build` with manifest version 1.5.3
- `ansible-test units --venv --requirements --python 3.12` (13 passed)
- `ansible-test sanity --venv --requirements --python 3.12`