### PR TITLE
test: raise branch coverage above 90%

### DIFF
--- a/.github/workflows/ansible-test-unit.yml
+++ b/.github/workflows/ansible-test-unit.yml
@@ -37,3 +37,14 @@ jobs:
           origin-python-version: ${{ matrix.origin-python-version }}
           # target-python-version:
           testing-type: units
+
+      # The upstream action creates this aggregate report after its internal
+      # Codecov step checks for it, so upload the finished report explicitly.
+      - name: Upload aggregate coverage to Codecov
+        if: matrix.ansible == 'stable-2.13'
+        uses: codecov/codecov-action@v7.0.0
+        with:
+          fail_ci_if_error: true
+          files: ansible_collections/community/healthchecksio/tests/output/reports/coverage=units.xml
+          flags: units
+          verbose: true

--- a/.github/workflows/ansible-test-unit.yml
+++ b/.github/workflows/ansible-test-unit.yml
@@ -32,6 +32,7 @@ jobs:
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
           ansible-core-version: ${{ matrix.ansible }}
+          coverage: always
           # pre-test-cmd:
           origin-python-version: ${{ matrix.origin-python-version }}
           # target-python-version:

--- a/changelogs/fragments/62-legacy-json-error.yml
+++ b/changelogs/fragments/62-legacy-json-error.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    Handle invalid API error-response JSON on legacy Python versions without
+    referencing the unavailable JSONDecodeError exception.

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,9 +2,13 @@ coverage:
   status:
     project:
       default:
-        informational: true # Don't fail CI
-# Don't count lines of code in these directories
+        target: 90%
+        threshold: 0%
+        informational: false
+        if_ci_failed: error
+
 ignore:
-    - tests
+  - tests
+
 fixes:
   - "ansible_collections/community/healthchecksio/::"

--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -31,7 +31,7 @@ class Response(object):
                 try:
                     json_body = json.loads(to_text(self.info["body"]))
                     return json_body
-                except json.decoder.JSONDecodeError:
+                except ValueError:
                     return {}
             return None
         try:

--- a/tests/unit/plugins/module_utils/test_healthchecksio.py
+++ b/tests/unit/plugins/module_utils/test_healthchecksio.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+__metaclass__ = type
+
 try:
     from unittest.mock import MagicMock, patch
 except ImportError:

--- a/tests/unit/plugins/module_utils/test_healthchecksio.py
+++ b/tests/unit/plugins/module_utils/test_healthchecksio.py
@@ -76,7 +76,7 @@ def service(cls, mod=None):
 
 def result_kwargs(mod):
     call = mod.fail_json.call_args if mod.fail_json.called else mod.exit_json.call_args
-    return call.kwargs
+    return call[1]
 
 
 def fetch_success():
@@ -116,8 +116,8 @@ def test_helper_initializes_and_forwards_connection_settings(fetch):
     mod = module(validate_certs=False, request_timeout=45, timeout=90)
     helper = HealthchecksioHelper(mod)
     helper.get("checks")
-    kwargs = fetch.call_args.kwargs
-    assert fetch.call_args.args[0] is mod
+    kwargs = fetch.call_args[1]
+    assert fetch.call_args[0][0] is mod
     assert kwargs["timeout"] == 45
     assert kwargs["headers"] == {"X-Api-Key": "token"}
     assert "validate_certs" not in kwargs
@@ -149,8 +149,8 @@ def test_helper_dispatches_methods(fetch, name, method):
     mod.jsonify.side_effect = lambda value: '{"name":"x"}'
     helper = HealthchecksioHelper(mod)
     getattr(helper, name)("checks", {"name": "x"})
-    assert fetch.call_args.kwargs["method"] == method
-    assert fetch.call_args.kwargs["data"] == '{"name":"x"}'
+    assert fetch.call_args[1]["method"] == method
+    assert fetch.call_args[1]["data"] == '{"name":"x"}'
 
 
 @patch(PATH + ".fetch_url", side_effect=lambda *args, **kwargs: fetch_success())
@@ -159,7 +159,7 @@ def test_helper_delete_omits_null_body(fetch):
     mod.jsonify.return_value = "null"
     helper = HealthchecksioHelper(mod)
     helper.delete("checks/id")
-    assert fetch.call_args.kwargs["data"] is None
+    assert fetch.call_args[1]["data"] is None
 
 
 @pytest.mark.parametrize("no_headers", [False, True])
@@ -167,7 +167,7 @@ def test_helper_delete_omits_null_body(fetch):
 def test_helper_head_headers(fetch, no_headers):
     helper = HealthchecksioHelper(module())
     helper.head("id", data=b"x", no_headers=no_headers)
-    kwargs = fetch.call_args.kwargs
+    kwargs = fetch.call_args[1]
     assert kwargs["method"] == "HEAD"
     assert kwargs["data"] == b"x"
     assert ("headers" not in kwargs) is no_headers
@@ -419,7 +419,7 @@ def test_create_simple_payload():
     obj.rest.post.return_value = response(201, existing())
     with pytest.raises(ExitJson) as exc:
         obj.create()
-    payload = obj.rest.post.call_args.kwargs["data"]
+    payload = obj.rest.post.call_args[1]["data"]
     assert payload["tags"] == "prod web"
     assert payload["timeout"] == 60
     for key in ("schedule", "tz", "uuid", "state", "validate_certs", "request_timeout"):
@@ -433,7 +433,7 @@ def test_create_cron_payload():
     obj.rest.post.return_value = response(201, existing())
     with pytest.raises(ExitJson):
         obj.create()
-    payload = obj.rest.post.call_args.kwargs["data"]
+    payload = obj.rest.post.call_args[1]["data"]
     assert payload["schedule"] == "0 1 * * *"
     assert "timeout" not in payload
 

--- a/tests/unit/plugins/module_utils/test_healthchecksio.py
+++ b/tests/unit/plugins/module_utils/test_healthchecksio.py
@@ -1,116 +1,496 @@
 from __future__ import absolute_import, division, print_function
 
-__metaclass__ = type
-
 try:
     from unittest.mock import MagicMock, patch
 except ImportError:
     from mock import MagicMock, patch
 
+import pytest
+
 from ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio import (
+    BadgesInfo,
+    ChannelsInfo,
+    Checks,
+    ChecksFlipsInfo,
+    ChecksInfo,
+    ChecksPingsInfo,
     HealthchecksioHelper,
     HealthchecksioPingHelper,
+    Response,
 )
 
 
-def _make_module(**overrides):
-    params = {
-        "state": "present",
-        "management_api_token": "test-token",
-        "management_api_base_url": "https://healthchecks.io/api/v1",
-        "ping_api_base_url": "https://hc-ping.com",
-        "ping_api_token": None,
-        "validate_certs": True,
-        "request_timeout": 30,
-    }
+class AnsibleResult(Exception):
+    def __init__(self, values=None, **kwargs):
+        self.kwargs = values or kwargs
+        Exception.__init__(self, self.kwargs)
+
+
+class ExitJson(AnsibleResult):
+    pass
+
+
+class FailJson(AnsibleResult):
+    pass
+
+
+PATH = (
+    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio"
+)
+
+
+def module(**overrides):
+    params = dict(
+        state="present",
+        management_api_token="token",
+        management_api_base_url="https://healthchecks.io/api/v1",
+        ping_api_base_url="https://hc-ping.com",
+        ping_api_token=None,
+        validate_certs=True,
+        request_timeout=30,
+    )
     params.update(overrides)
-    module = MagicMock()
-    module.params = params
-    module.jsonify.side_effect = lambda value: value
-    return module
+    result = MagicMock()
+    result.params = params
+    result.check_mode = False
+    result.diff_mode = False
+    result.jsonify.side_effect = lambda value: value
+    result.exit_json.side_effect = ExitJson
+    result.fail_json.side_effect = FailJson
+    return result
 
 
-def _mock_fetch_success():
+def response(status=200, data=None):
+    result = MagicMock()
+    result.status_code = status
+    result.json = {} if data is None else data
+    return result
+
+
+def service(cls, mod=None):
+    result = cls.__new__(cls)
+    result.module = mod or module()
+    result.rest = MagicMock()
+    return result
+
+
+def result_kwargs(mod):
+    call = mod.fail_json.call_args if mod.fail_json.called else mod.exit_json.call_args
+    return call.kwargs
+
+
+def fetch_success():
     resp = MagicMock()
     resp.read.return_value = b'{"checks": []}'
-    info = {"status": 200}
-    return resp, info
+    return resp, {"status": 200}
 
 
-def _last_fetch_kwargs(mock_fetch_url):
-    return mock_fetch_url.call_args_list[-1][1]
+def test_response_parses_body_and_status():
+    resp = MagicMock()
+    resp.read.return_value = b'{"ok": true}'
+    result = Response(resp, {"status": 201})
+    assert result.json == {"ok": True}
+    assert result.status_code == 201
 
 
-def _last_fetch_module(mock_fetch_url):
-    return mock_fetch_url.call_args_list[-1][0][0]
-
-
-@patch(
-    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url",
-    side_effect=lambda *args, **kwargs: _mock_fetch_success(),
+@pytest.mark.parametrize(
+    "resp,info,expected",
+    [
+        (None, {"status": 204}, None),
+        (None, {"status": 400, "body": b'{"error": "bad"}'}, {"error": "bad"}),
+        (None, {"status": 500, "body": b"bad"}, {}),
+    ],
 )
-def test_helper_fetch_url_defaults(mock_fetch_url):
-    module = _make_module()
-    helper = HealthchecksioHelper(module)
+def test_response_handles_info_body(resp, info, expected):
+    assert Response(resp, info).json == expected
+
+
+def test_response_handles_invalid_body():
+    resp = MagicMock()
+    resp.read.return_value = b"bad"
+    assert Response(resp, {"status": 200}).json is None
+
+
+@patch(PATH + ".fetch_url", side_effect=lambda *args, **kwargs: fetch_success())
+def test_helper_initializes_and_forwards_connection_settings(fetch):
+    mod = module(validate_certs=False, request_timeout=45, timeout=90)
+    helper = HealthchecksioHelper(mod)
     helper.get("checks")
-
-    kwargs = _last_fetch_kwargs(mock_fetch_url)
-    assert "validate_certs" not in kwargs
-    assert _last_fetch_module(mock_fetch_url).params["validate_certs"] is True
-    assert kwargs["timeout"] == 30
-
-
-@patch(
-    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url",
-    side_effect=lambda *args, **kwargs: _mock_fetch_success(),
-)
-def test_helper_fetch_url_validate_certs_false(mock_fetch_url):
-    module = _make_module(validate_certs=False)
-    helper = HealthchecksioHelper(module)
-    helper.get("checks")
-
-    kwargs = _last_fetch_kwargs(mock_fetch_url)
-    assert "validate_certs" not in kwargs
-    assert _last_fetch_module(mock_fetch_url).params["validate_certs"] is False
-
-
-@patch(
-    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url",
-    side_effect=lambda *args, **kwargs: _mock_fetch_success(),
-)
-def test_helper_fetch_url_request_timeout(mock_fetch_url):
-    module = _make_module(request_timeout=99)
-    helper = HealthchecksioHelper(module)
-    helper.get("checks")
-
-    kwargs = _last_fetch_kwargs(mock_fetch_url)
-    assert kwargs["timeout"] == 99
-
-
-@patch(
-    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url",
-    side_effect=lambda *args, **kwargs: _mock_fetch_success(),
-)
-def test_helper_fetch_url_ignores_check_timeout_param(mock_fetch_url):
-    module = _make_module(timeout=77)
-    helper = HealthchecksioHelper(module)
-    helper.get("checks")
-
-    kwargs = _last_fetch_kwargs(mock_fetch_url)
-    assert kwargs["timeout"] == 30
-
-
-@patch(
-    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url",
-    side_effect=lambda *args, **kwargs: _mock_fetch_success(),
-)
-def test_ping_helper_head_forwards_connection_params(mock_fetch_url):
-    module = _make_module(validate_certs=False, request_timeout=45)
-    helper = HealthchecksioPingHelper(module)
-    helper.head("check-uuid", no_headers=True)
-
-    kwargs = _last_fetch_kwargs(mock_fetch_url)
-    assert kwargs["method"] == "HEAD"
-    assert "validate_certs" not in kwargs
-    assert _last_fetch_module(mock_fetch_url).params["validate_certs"] is False
+    kwargs = fetch.call_args.kwargs
+    assert fetch.call_args.args[0] is mod
     assert kwargs["timeout"] == 45
+    assert kwargs["headers"] == {"X-Api-Key": "token"}
+    assert "validate_certs" not in kwargs
+
+
+@patch(PATH + ".fetch_url")
+def test_helper_rejects_invalid_token(fetch):
+    fetch.return_value = (None, {"status": 401, "body": b"{}"})
+    mod = module()
+    with pytest.raises(FailJson):
+        HealthchecksioHelper(mod)
+    assert "Failed to login" in result_kwargs(mod)["msg"]
+
+
+@patch(PATH + ".fetch_url", side_effect=lambda *args, **kwargs: fetch_success())
+def test_helper_builds_urls(fetch):
+    helper = HealthchecksioHelper(module())
+    assert helper._url_builder("checks") == "https://healthchecks.io/api/v1/checks"
+    assert helper._url_builder("/checks") == "https://healthchecks.io/api/v1/checks"
+
+
+@pytest.mark.parametrize(
+    "name,method",
+    [("get", "GET"), ("put", "PUT"), ("post", "POST"), ("delete", "DELETE")],
+)
+@patch(PATH + ".fetch_url", side_effect=lambda *args, **kwargs: fetch_success())
+def test_helper_dispatches_methods(fetch, name, method):
+    mod = module()
+    mod.jsonify.side_effect = lambda value: '{"name":"x"}'
+    helper = HealthchecksioHelper(mod)
+    getattr(helper, name)("checks", {"name": "x"})
+    assert fetch.call_args.kwargs["method"] == method
+    assert fetch.call_args.kwargs["data"] == '{"name":"x"}'
+
+
+@patch(PATH + ".fetch_url", side_effect=lambda *args, **kwargs: fetch_success())
+def test_helper_delete_omits_null_body(fetch):
+    mod = module()
+    mod.jsonify.return_value = "null"
+    helper = HealthchecksioHelper(mod)
+    helper.delete("checks/id")
+    assert fetch.call_args.kwargs["data"] is None
+
+
+@pytest.mark.parametrize("no_headers", [False, True])
+@patch(PATH + ".fetch_url", side_effect=lambda *args, **kwargs: fetch_success())
+def test_helper_head_headers(fetch, no_headers):
+    helper = HealthchecksioHelper(module())
+    helper.head("id", data=b"x", no_headers=no_headers)
+    kwargs = fetch.call_args.kwargs
+    assert kwargs["method"] == "HEAD"
+    assert kwargs["data"] == b"x"
+    assert ("headers" not in kwargs) is no_headers
+
+
+def test_argument_spec():
+    spec = HealthchecksioHelper.healthchecksio_argument_spec()
+    assert spec["state"]["choices"] == ["present", "absent"]
+    assert spec["management_api_token"]["no_log"] is True
+    assert (
+        spec["management_api_base_url"]["default"] == "https://healthchecks.io/api/v1"
+    )
+    assert spec["ping_api_base_url"]["default"] == "https://hc-ping.com"
+    assert spec["validate_certs"]["default"] is True
+    assert spec["request_timeout"]["default"] == 30
+
+
+@pytest.mark.parametrize(
+    "ping_token,expected", [("ping", "ping"), ("", "token"), (None, None)]
+)
+def test_ping_helper_settings(ping_token, expected):
+    helper = HealthchecksioPingHelper.__new__(HealthchecksioPingHelper)
+    mod = module(ping_api_token=ping_token)
+    assert helper._get_api_token(mod) == expected
+    assert helper._get_base_url(mod) == "https://hc-ping.com"
+
+
+@pytest.mark.parametrize(
+    "cls,endpoint", [(BadgesInfo, "badges"), (ChannelsInfo, "channels")]
+)
+def test_simple_info_success(cls, endpoint):
+    obj = service(cls)
+    obj.rest.get.return_value = response(data={"items": [1]})
+    with pytest.raises(ExitJson) as exc:
+        obj.get()
+    obj.rest.get.assert_called_once_with(endpoint)
+    assert result_kwargs(obj.module) == {"changed": False, "data": {"items": [1]}}
+
+
+@pytest.mark.parametrize(
+    "cls,endpoint", [(BadgesInfo, "badges"), (ChannelsInfo, "channels")]
+)
+@pytest.mark.parametrize(
+    "data,text", [({"message": "denied"}, "denied"), ({}, "(empty error message)")]
+)
+def test_simple_info_failure(cls, endpoint, data, text):
+    obj = service(cls)
+    obj.rest.get.return_value = response(403, data)
+    with pytest.raises(FailJson) as exc:
+        obj.get()
+    assert endpoint in result_kwargs(obj.module)["msg"]
+    assert text in result_kwargs(obj.module)["msg"]
+
+
+@pytest.mark.parametrize(
+    "cls,suffix", [(ChecksFlipsInfo, "flips"), (ChecksPingsInfo, "pings")]
+)
+@pytest.mark.parametrize("status,exception", [(200, ExitJson), (500, FailJson)])
+def test_check_events(cls, suffix, status, exception):
+    obj = service(cls, module(uuid="abc"))
+    obj.rest.get.return_value = response(status, {"message": "down"})
+    with pytest.raises(exception) as exc:
+        obj.get()
+    obj.rest.get.assert_called_once_with("checks/abc/" + suffix)
+    if status == 200:
+        assert result_kwargs(obj.module)["data"] == {"message": "down"}
+    elif cls is ChecksPingsInfo:
+        assert "down" in result_kwargs(obj.module)["msg"]
+
+
+@pytest.mark.parametrize(
+    "params,endpoint",
+    [
+        ({}, "checks"),
+        ({"tags": []}, "checks"),
+        ({"tags": ["prod", "web"]}, "checks?tag=prod&tag=web"),
+        ({"uuid": "abc"}, "checks/abc"),
+        ({"name": "nightly job"}, "checks?name=nightly%20job"),
+        ({"tags": ["prod"], "name": "a/b"}, "checks?tag=prod&name=a%2Fb"),
+    ],
+)
+def test_checks_info_endpoints(params, endpoint):
+    obj = service(ChecksInfo, module(**params))
+    obj.rest.get.return_value = response(data={"checks": []})
+    with pytest.raises(ExitJson):
+        obj.get()
+    obj.rest.get.assert_called_once_with(endpoint)
+
+
+def test_checks_info_failure():
+    obj = service(ChecksInfo, module(tags=["prod"]))
+    obj.rest.get.return_value = response(500)
+    with pytest.raises(FailJson) as exc:
+        obj.get()
+    assert "checks?tag=prod" in result_kwargs(obj.module)["msg"]
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        ({"ping_url": "https://hc-ping.com/abc"}, "abc"),
+        ({"ping_url": "https://hc-ping.com/"}, "(unable to determine uuid)"),
+        ({}, "(unable to determine uuid)"),
+    ],
+)
+def test_get_uuid(data, expected):
+    assert service(Checks).get_uuid(data) == expected
+
+
+def check_params(**overrides):
+    result = dict(
+        name="nightly",
+        slug="nightly",
+        timeout=60,
+        schedule=None,
+        tz=None,
+        grace=3600,
+        channels="email,slack",
+        tags=["prod", "web"],
+        unique=["name"],
+        desc=None,
+        uuid=None,
+        state="present",
+        validate_certs=True,
+        request_timeout=30,
+        management_api_token="token",
+        management_api_base_url="https://healthchecks.io/api/v1",
+        ping_api_token=None,
+        ping_api_base_url="https://hc-ping.com",
+    )
+    result.update(overrides)
+    return result
+
+
+def existing(**overrides):
+    result = dict(
+        name="nightly",
+        slug="nightly",
+        timeout=60,
+        schedule=None,
+        tz=None,
+        channels="email,slack",
+        tags="prod web",
+        ping_url="https://hc-ping.com/abc",
+    )
+    result.update(overrides)
+    return result
+
+
+def checks(**overrides):
+    return service(Checks, module(**check_params(**overrides)))
+
+
+def request_params(obj):
+    result = dict(obj.module.params)
+    for key in ("uuid", "state", "validate_certs", "request_timeout"):
+        result.pop(key, None)
+    if result.get("schedule") and result.get("tz"):
+        result.pop("timeout")
+    if result.get("timeout"):
+        result.pop("schedule")
+        result.pop("tz")
+    result["tags"] = " ".join(obj.module.params.get("tags", []))
+    return result
+
+
+def test_find_existing_match():
+    obj = checks()
+    found = existing()
+    obj.rest.get.return_value = response(data={"checks": [found]})
+    assert obj._find_existing_check(request_params(obj)) == found
+
+
+@pytest.mark.parametrize(
+    "change", [{"slug": "other"}, {"channels": "other"}, {"tags": "other"}]
+)
+def test_find_existing_rejects_difference(change):
+    obj = checks()
+    obj.rest.get.return_value = response(data={"checks": [existing(**change)]})
+    assert obj._find_existing_check(request_params(obj)) is None
+
+
+def test_find_existing_channel_order():
+    obj = checks()
+    found = existing(channels="slack,email")
+    obj.rest.get.return_value = response(data={"checks": [found]})
+    assert obj._find_existing_check(request_params(obj)) == found
+
+
+def test_find_existing_resolves_all_channels():
+    obj = checks(channels="*")
+    found = existing()
+    obj.rest.get.side_effect = [
+        response(data={"checks": [found]}),
+        response(data={"channels": [{"id": "email"}, {"id": "slack"}]}),
+    ]
+    assert obj._find_existing_check(request_params(obj)) == found
+
+
+def test_find_existing_ambiguous_unique_fails():
+    obj = checks()
+    obj.rest.get.return_value = response(data={"checks": [existing(), existing()]})
+    with pytest.raises(FailJson) as exc:
+        obj._find_existing_check(request_params(obj))
+    assert "2 found" in result_kwargs(obj.module)["msg"]
+
+
+def test_find_existing_empty_unique_allows_multiple():
+    obj = checks(unique=[])
+    obj.rest.get.return_value = response(data={"checks": [existing(), existing()]})
+    assert obj._find_existing_check(request_params(obj)) is None
+
+
+@pytest.mark.parametrize("found,changed", [(existing(), False), (None, True)])
+def test_create_check_mode(found, changed):
+    obj = checks()
+    obj.module.check_mode = True
+    obj._find_existing_check = MagicMock(return_value=found)
+    with pytest.raises(ExitJson) as exc:
+        obj.create()
+    assert result_kwargs(obj.module)["changed"] is changed
+    assert result_kwargs(obj.module)["uuid"] == ("abc" if found else "")
+    obj.rest.post.assert_not_called()
+
+
+def test_create_idempotent():
+    obj = checks()
+    obj._find_existing_check = MagicMock(return_value=existing())
+    with pytest.raises(ExitJson) as exc:
+        obj.create()
+    assert result_kwargs(obj.module)["changed"] is False
+    obj.rest.post.assert_not_called()
+
+
+def test_create_idempotent_with_all_channels():
+    obj = checks(channels="*")
+    obj._find_existing_check = MagicMock(return_value=existing())
+    obj.rest.get.return_value = response(
+        data={"channels": [{"id": "email"}, {"id": "slack"}]}
+    )
+    with pytest.raises(ExitJson) as exc:
+        obj.create()
+    assert result_kwargs(obj.module)["changed"] is False
+
+
+def test_create_simple_payload():
+    obj = checks()
+    obj._find_existing_check = MagicMock(return_value=None)
+    obj.rest.post.return_value = response(201, existing())
+    with pytest.raises(ExitJson) as exc:
+        obj.create()
+    payload = obj.rest.post.call_args.kwargs["data"]
+    assert payload["tags"] == "prod web"
+    assert payload["timeout"] == 60
+    for key in ("schedule", "tz", "uuid", "state", "validate_certs", "request_timeout"):
+        assert key not in payload
+    assert result_kwargs(obj.module)["msg"] == "New check abc created"
+
+
+def test_create_cron_payload():
+    obj = checks(timeout=None, schedule="0 1 * * *", tz="UTC")
+    obj._find_existing_check = MagicMock(return_value=None)
+    obj.rest.post.return_value = response(201, existing())
+    with pytest.raises(ExitJson):
+        obj.create()
+    payload = obj.rest.post.call_args.kwargs["data"]
+    assert payload["schedule"] == "0 1 * * *"
+    assert "timeout" not in payload
+
+
+def test_create_updates_changed_check():
+    obj = checks(slug="new")
+    obj._find_existing_check = MagicMock(return_value=existing())
+    obj.rest.post.return_value = response(200, existing(slug="new"))
+    with pytest.raises(ExitJson) as exc:
+        obj.create()
+    assert result_kwargs(obj.module)["changed"] is True
+    assert "found and updated" in result_kwargs(obj.module)["msg"]
+
+
+@pytest.mark.parametrize(
+    "data,text", [({"error": "invalid"}, "invalid"), ({}, "(empty error message)")]
+)
+def test_create_failure(data, text):
+    obj = checks()
+    obj._find_existing_check = MagicMock(return_value=None)
+    obj.rest.post.return_value = response(422, data)
+    with pytest.raises(FailJson) as exc:
+        obj.create()
+    assert text in result_kwargs(obj.module)["msg"]
+
+
+@pytest.mark.parametrize(
+    "operation,http_method", [("delete", "delete"), ("pause", "post")]
+)
+def test_destructive_check_mode(operation, http_method):
+    obj = checks(uuid="abc")
+    obj.module.check_mode = True
+    with pytest.raises(ExitJson) as exc:
+        getattr(obj, operation)()
+    assert result_kwargs(obj.module)["changed"] is True
+    getattr(obj.rest, http_method).assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "operation,http_method,suffix",
+    [("delete", "delete", ""), ("pause", "post", "/pause")],
+)
+@pytest.mark.parametrize(
+    "status,changed,text,exception",
+    [
+        (200, True, "successfully", ExitJson),
+        (404, False, "not found", ExitJson),
+        (500, False, "Failed", FailJson),
+    ],
+)
+def test_destructive_results(
+    operation, http_method, suffix, status, changed, text, exception
+):
+    obj = checks(uuid="abc")
+    getattr(obj.rest, http_method).return_value = response(status)
+    with pytest.raises(exception) as exc:
+        getattr(obj, operation)()
+    getattr(obj.rest, http_method).assert_called_once_with("checks/abc" + suffix)
+    assert result_kwargs(obj.module)["changed"] is changed
+    assert text in result_kwargs(obj.module)["msg"]

--- a/tests/unit/plugins/modules/test_badges_info.py
+++ b/tests/unit/plugins/modules/test_badges_info.py
@@ -32,7 +32,7 @@ def test_run_ignores_unknown_state():
 def test_main_builds_check_mode_module_and_runs_it():
     module = make_module()
     ansible_module = run_main(badges_info, module)
-    kwargs = ansible_module.call_args.kwargs
+    kwargs = ansible_module.call_args[1]
     assert kwargs["supports_check_mode"] is True
     assert kwargs["argument_spec"]["state"] == dict(
         type="str", choices=["present"], default="present"

--- a/tests/unit/plugins/modules/test_badges_info.py
+++ b/tests/unit/plugins/modules/test_badges_info.py
@@ -2,6 +2,38 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
-def test_badges_info_placeholder():
-    assert True
+from ansible_collections.community.healthchecksio.plugins.modules import badges_info
+from ansible_collections.community.healthchecksio.tests.unit.plugins.modules.utils import (
+    make_module,
+    run_main,
+)
+
+
+def test_run_gets_badges_for_present_state():
+    module = make_module(state="present")
+    with patch.object(badges_info, "BadgesInfo") as badges:
+        badges_info.run(module)
+    badges.assert_called_once_with(module)
+    badges.return_value.get.assert_called_once_with()
+
+
+def test_run_ignores_unknown_state():
+    module = make_module(state="unknown")
+    with patch.object(badges_info, "BadgesInfo") as badges:
+        badges_info.run(module)
+    badges.return_value.get.assert_not_called()
+
+
+def test_main_builds_check_mode_module_and_runs_it():
+    module = make_module()
+    ansible_module = run_main(badges_info, module)
+    kwargs = ansible_module.call_args.kwargs
+    assert kwargs["supports_check_mode"] is True
+    assert kwargs["argument_spec"]["state"] == dict(
+        type="str", choices=["present"], default="present"
+    )

--- a/tests/unit/plugins/modules/test_channels_info.py
+++ b/tests/unit/plugins/modules/test_channels_info.py
@@ -32,7 +32,7 @@ def test_run_ignores_unknown_state():
 def test_main_builds_check_mode_module_and_runs_it():
     module = make_module()
     ansible_module = run_main(channels_info, module)
-    kwargs = ansible_module.call_args.kwargs
+    kwargs = ansible_module.call_args[1]
     assert kwargs["supports_check_mode"] is True
     assert kwargs["argument_spec"]["state"] == dict(
         type="str", choices=["present"], default="present"

--- a/tests/unit/plugins/modules/test_channels_info.py
+++ b/tests/unit/plugins/modules/test_channels_info.py
@@ -2,6 +2,38 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
-def test_channels_info_placeholder():
-    assert True
+from ansible_collections.community.healthchecksio.plugins.modules import channels_info
+from ansible_collections.community.healthchecksio.tests.unit.plugins.modules.utils import (
+    make_module,
+    run_main,
+)
+
+
+def test_run_gets_channels_for_present_state():
+    module = make_module(state="present")
+    with patch.object(channels_info, "ChannelsInfo") as channels:
+        channels_info.run(module)
+    channels.assert_called_once_with(module)
+    channels.return_value.get.assert_called_once_with()
+
+
+def test_run_ignores_unknown_state():
+    module = make_module(state="unknown")
+    with patch.object(channels_info, "ChannelsInfo") as channels:
+        channels_info.run(module)
+    channels.return_value.get.assert_not_called()
+
+
+def test_main_builds_check_mode_module_and_runs_it():
+    module = make_module()
+    ansible_module = run_main(channels_info, module)
+    kwargs = ansible_module.call_args.kwargs
+    assert kwargs["supports_check_mode"] is True
+    assert kwargs["argument_spec"]["state"] == dict(
+        type="str", choices=["present"], default="present"
+    )

--- a/tests/unit/plugins/modules/test_checks.py
+++ b/tests/unit/plugins/modules/test_checks.py
@@ -40,7 +40,7 @@ def test_run_ignores_unknown_state():
 def test_main_builds_state_constraints_and_runs_module():
     module = make_module()
     ansible_module = run_main(checks, module)
-    kwargs = ansible_module.call_args.kwargs
+    kwargs = ansible_module.call_args[1]
     assert kwargs["supports_check_mode"] is True
     assert kwargs["required_if"] == [
         ("state", "absent", ["uuid"]),

--- a/tests/unit/plugins/modules/test_checks.py
+++ b/tests/unit/plugins/modules/test_checks.py
@@ -2,6 +2,57 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
-def test_checks_placeholder():
-    assert True
+import pytest
+
+from ansible_collections.community.healthchecksio.plugins.modules import checks
+from ansible_collections.community.healthchecksio.tests.unit.plugins.modules.utils import (
+    make_module,
+    run_main,
+)
+
+
+@pytest.mark.parametrize(
+    ("state", "method"),
+    [("present", "create"), ("absent", "delete"), ("pause", "pause")],
+)
+def test_run_dispatches_state(state, method):
+    module = make_module(state=state)
+    with patch.object(checks, "Checks") as checks_class:
+        checks.run(module)
+    checks_class.assert_called_once_with(module)
+    getattr(checks_class.return_value, method).assert_called_once_with()
+
+
+def test_run_ignores_unknown_state():
+    module = make_module(state="unknown")
+    with patch.object(checks, "Checks") as checks_class:
+        checks.run(module)
+    checks_class.return_value.create.assert_not_called()
+    checks_class.return_value.delete.assert_not_called()
+    checks_class.return_value.pause.assert_not_called()
+
+
+def test_main_builds_state_constraints_and_runs_module():
+    module = make_module()
+    ansible_module = run_main(checks, module)
+    kwargs = ansible_module.call_args.kwargs
+    assert kwargs["supports_check_mode"] is True
+    assert kwargs["required_if"] == [
+        ("state", "absent", ["uuid"]),
+        ("state", "pause", ["uuid"]),
+    ]
+    assert kwargs["required_together"] == [("schedule", "tz")]
+    assert kwargs["mutually_exclusive"] == [
+        ("timeout", "schedule"),
+        ("timeout", "tz"),
+    ]
+    assert kwargs["argument_spec"]["state"]["choices"] == [
+        "present",
+        "absent",
+        "pause",
+    ]

--- a/tests/unit/plugins/modules/test_checks_flips_info.py
+++ b/tests/unit/plugins/modules/test_checks_flips_info.py
@@ -2,6 +2,38 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
-def test_checks_flips_info_placeholder():
-    assert True
+from ansible_collections.community.healthchecksio.plugins.modules import (
+    checks_flips_info,
+)
+from ansible_collections.community.healthchecksio.tests.unit.plugins.modules.utils import (
+    make_module,
+    run_main,
+)
+
+
+def test_run_gets_flips_for_present_state():
+    module = make_module(state="present")
+    with patch.object(checks_flips_info, "ChecksFlipsInfo") as flips:
+        checks_flips_info.run(module)
+    flips.assert_called_once_with(module)
+    flips.return_value.get.assert_called_once_with()
+
+
+def test_run_ignores_unknown_state():
+    module = make_module(state="unknown")
+    with patch.object(checks_flips_info, "ChecksFlipsInfo") as flips:
+        checks_flips_info.run(module)
+    flips.return_value.get.assert_not_called()
+
+
+def test_main_builds_check_mode_module_and_runs_it():
+    module = make_module()
+    ansible_module = run_main(checks_flips_info, module)
+    kwargs = ansible_module.call_args.kwargs
+    assert kwargs["supports_check_mode"] is True
+    assert kwargs["argument_spec"]["uuid"] == dict(type="str", required=False)

--- a/tests/unit/plugins/modules/test_checks_flips_info.py
+++ b/tests/unit/plugins/modules/test_checks_flips_info.py
@@ -34,6 +34,6 @@ def test_run_ignores_unknown_state():
 def test_main_builds_check_mode_module_and_runs_it():
     module = make_module()
     ansible_module = run_main(checks_flips_info, module)
-    kwargs = ansible_module.call_args.kwargs
+    kwargs = ansible_module.call_args[1]
     assert kwargs["supports_check_mode"] is True
     assert kwargs["argument_spec"]["uuid"] == dict(type="str", required=False)

--- a/tests/unit/plugins/modules/test_checks_info.py
+++ b/tests/unit/plugins/modules/test_checks_info.py
@@ -32,7 +32,7 @@ def test_run_ignores_unknown_state():
 def test_main_builds_filters_and_runs_module():
     module = make_module()
     ansible_module = run_main(checks_info, module)
-    kwargs = ansible_module.call_args.kwargs
+    kwargs = ansible_module.call_args[1]
     assert kwargs["supports_check_mode"] is True
     assert kwargs["mutually_exclusive"] == [("tags", "uuid"), ("name", "uuid")]
     assert set(("tags", "uuid", "name")) <= set(kwargs["argument_spec"])

--- a/tests/unit/plugins/modules/test_checks_info.py
+++ b/tests/unit/plugins/modules/test_checks_info.py
@@ -2,6 +2,37 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
-def test_checks_info_placeholder():
-    assert True
+from ansible_collections.community.healthchecksio.plugins.modules import checks_info
+from ansible_collections.community.healthchecksio.tests.unit.plugins.modules.utils import (
+    make_module,
+    run_main,
+)
+
+
+def test_run_gets_checks_for_present_state():
+    module = make_module(state="present")
+    with patch.object(checks_info, "ChecksInfo") as checks:
+        checks_info.run(module)
+    checks.assert_called_once_with(module)
+    checks.return_value.get.assert_called_once_with()
+
+
+def test_run_ignores_unknown_state():
+    module = make_module(state="unknown")
+    with patch.object(checks_info, "ChecksInfo") as checks:
+        checks_info.run(module)
+    checks.return_value.get.assert_not_called()
+
+
+def test_main_builds_filters_and_runs_module():
+    module = make_module()
+    ansible_module = run_main(checks_info, module)
+    kwargs = ansible_module.call_args.kwargs
+    assert kwargs["supports_check_mode"] is True
+    assert kwargs["mutually_exclusive"] == [("tags", "uuid"), ("name", "uuid")]
+    assert set(("tags", "uuid", "name")) <= set(kwargs["argument_spec"])

--- a/tests/unit/plugins/modules/test_checks_pings_info.py
+++ b/tests/unit/plugins/modules/test_checks_pings_info.py
@@ -34,6 +34,6 @@ def test_run_ignores_unknown_state():
 def test_main_builds_check_mode_module_and_runs_it():
     module = make_module()
     ansible_module = run_main(checks_pings_info, module)
-    kwargs = ansible_module.call_args.kwargs
+    kwargs = ansible_module.call_args[1]
     assert kwargs["supports_check_mode"] is True
     assert kwargs["argument_spec"]["uuid"] == dict(type="str", required=False)

--- a/tests/unit/plugins/modules/test_checks_pings_info.py
+++ b/tests/unit/plugins/modules/test_checks_pings_info.py
@@ -2,6 +2,38 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
-def test_checks_pings_info_placeholder():
-    assert True
+from ansible_collections.community.healthchecksio.plugins.modules import (
+    checks_pings_info,
+)
+from ansible_collections.community.healthchecksio.tests.unit.plugins.modules.utils import (
+    make_module,
+    run_main,
+)
+
+
+def test_run_gets_pings_for_present_state():
+    module = make_module(state="present")
+    with patch.object(checks_pings_info, "ChecksPingsInfo") as pings:
+        checks_pings_info.run(module)
+    pings.assert_called_once_with(module)
+    pings.return_value.get.assert_called_once_with()
+
+
+def test_run_ignores_unknown_state():
+    module = make_module(state="unknown")
+    with patch.object(checks_pings_info, "ChecksPingsInfo") as pings:
+        checks_pings_info.run(module)
+    pings.return_value.get.assert_not_called()
+
+
+def test_main_builds_check_mode_module_and_runs_it():
+    module = make_module()
+    ansible_module = run_main(checks_pings_info, module)
+    kwargs = ansible_module.call_args.kwargs
+    assert kwargs["supports_check_mode"] is True
+    assert kwargs["argument_spec"]["uuid"] == dict(type="str", required=False)

--- a/tests/unit/plugins/modules/test_ping.py
+++ b/tests/unit/plugins/modules/test_ping.py
@@ -151,7 +151,7 @@ def test_run_ignores_unknown_state():
 def test_main_builds_ping_arguments_and_runs_module():
     module = _make_module()
     ansible_module = run_main(ping_module, module)
-    kwargs = ansible_module.call_args.kwargs
+    kwargs = ansible_module.call_args[1]
     assert kwargs["supports_check_mode"] is True
     assert kwargs["argument_spec"]["uuid"] == dict(type="str", required=True)
     assert kwargs["argument_spec"]["signal"]["choices"] == [

--- a/tests/unit/plugins/modules/test_ping.py
+++ b/tests/unit/plugins/modules/test_ping.py
@@ -7,15 +7,24 @@ try:
 except ImportError:
     from mock import MagicMock, patch
 
+import pytest
+
 from ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio import (
     Ping,
 )
 from ansible_collections.community.healthchecksio.plugins.modules import (
     ping as ping_module,
 )
+from ansible_collections.community.healthchecksio.tests.unit.plugins.modules.utils import (
+    run_main,
+)
 
 
 class ExitJson(Exception):
+    pass
+
+
+class FailJson(Exception):
     pass
 
 
@@ -34,14 +43,14 @@ def _make_module(**overrides):
     module.check_mode = False
     module.jsonify.side_effect = lambda value: value
     module.exit_json.side_effect = ExitJson
+    module.fail_json.side_effect = FailJson
     return module
 
 
-def _mock_fetch_success():
+def _mock_fetch(status=200, body=b'{"checks": []}'):
     resp = MagicMock()
-    resp.read.return_value = b'{"checks": []}'
-    info = {"status": 200}
-    return resp, info
+    resp.read.return_value = body
+    return resp, {"status": status}
 
 
 def _last_fetch_url(mock_fetch_url):
@@ -49,30 +58,66 @@ def _last_fetch_url(mock_fetch_url):
 
 
 @patch(
-    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url",
-    side_effect=lambda *args, **kwargs: _mock_fetch_success(),
+    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url"
 )
-def test_ping_create_appends_runid_as_rid_query_param(mock_fetch_url):
+@pytest.mark.parametrize(
+    ("signal", "endpoint"),
+    [
+        ("success", "check-uuid"),
+        ("start", "check-uuid/start"),
+        ("fail", "check-uuid/fail"),
+    ],
+)
+def test_ping_create_sends_each_signal(mock_fetch_url, signal, endpoint):
+    mock_fetch_url.return_value = _mock_fetch()
     module = _make_module()
-    ping = Ping(module)
+    with pytest.raises(ExitJson):
+        Ping(module).create("check-uuid", signal)
+    assert _last_fetch_url(mock_fetch_url) == "https://hc-ping.com/" + endpoint
+    module.exit_json.assert_called_once_with(
+        changed=True,
+        msg="Sent {0} signal to {1}".format(signal, endpoint),
+    )
 
-    try:
-        ping.create(
-            "check-uuid",
-            "start",
-            "728b3763-ea80-4113-9fc0-f49b3adf226a",
-        )
-    except ExitJson:
-        pass
 
+@patch(
+    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url"
+)
+def test_ping_create_appends_encoded_runid_as_rid_query_param(mock_fetch_url):
+    mock_fetch_url.return_value = _mock_fetch()
+    module = _make_module()
+    with pytest.raises(ExitJson):
+        Ping(module).create("check-uuid", "start", "run id/1")
     assert (
         _last_fetch_url(mock_fetch_url)
-        == "https://hc-ping.com/check-uuid/start?rid=728b3763-ea80-4113-9fc0-f49b3adf226a"
+        == "https://hc-ping.com/check-uuid/start?rid=run%20id%2F1"
     )
     module.exit_json.assert_called_once_with(
         changed=True,
         msg="Sent start signal to check-uuid/start",
     )
+
+
+@patch(
+    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url"
+)
+def test_ping_create_reports_http_failure(mock_fetch_url):
+    mock_fetch_url.return_value = _mock_fetch(status=503)
+    module = _make_module()
+    with pytest.raises(FailJson):
+        Ping(module).create("check-uuid", "fail")
+    module.fail_json.assert_called_once_with(
+        changed=False,
+        msg="Failed to send fail signal to check-uuid/fail [HTTP 503]",
+    )
+
+
+def test_ping_create_is_noop_in_check_mode():
+    module = _make_module()
+    module.check_mode = True
+    with pytest.raises(ExitJson):
+        Ping(module).create("check-uuid", "success")
+    module.exit_json.assert_called_once_with(changed=False, data={})
 
 
 def test_run_passes_runid_to_ping():
@@ -82,12 +127,36 @@ def test_run_passes_runid_to_ping():
         signal="success",
         runid="728b3763-ea80-4113-9fc0-f49b3adf226a",
     )
-
-    with patch.object(ping_module, "Ping") as ping_cls:
+    with patch.object(ping_module, "Ping") as ping_class:
         ping_module.run(module)
-
-    ping_cls.return_value.create.assert_called_once_with(
+    ping_class.return_value.create.assert_called_once_with(
         "check-uuid",
         "success",
         "728b3763-ea80-4113-9fc0-f49b3adf226a",
     )
+
+
+def test_run_ignores_unknown_state():
+    module = _make_module(
+        state="unknown",
+        uuid="check-uuid",
+        signal="success",
+        runid=None,
+    )
+    with patch.object(ping_module, "Ping") as ping_class:
+        ping_module.run(module)
+    ping_class.return_value.create.assert_not_called()
+
+
+def test_main_builds_ping_arguments_and_runs_module():
+    module = _make_module()
+    ansible_module = run_main(ping_module, module)
+    kwargs = ansible_module.call_args.kwargs
+    assert kwargs["supports_check_mode"] is True
+    assert kwargs["argument_spec"]["uuid"] == dict(type="str", required=True)
+    assert kwargs["argument_spec"]["signal"]["choices"] == [
+        "success",
+        "fail",
+        "start",
+    ]
+    assert kwargs["argument_spec"]["runid"] == dict(type="str", required=False)

--- a/tests/unit/plugins/modules/utils.py
+++ b/tests/unit/plugins/modules/utils.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+try:
+    from unittest.mock import MagicMock, patch
+except ImportError:
+    from mock import MagicMock, patch
+
+
+def make_module(**params):
+    module = MagicMock()
+    module.params = dict(params)
+    module.check_mode = False
+    module.diff_mode = False
+    return module
+
+
+def run_main(module_under_test, module):
+    with patch.object(
+        module_under_test, "AnsibleModule", return_value=module
+    ) as ansible_module:
+        with patch.object(module_under_test, "run") as run:
+            module_under_test.main()
+    run.assert_called_once_with(module)
+    return ansible_module


### PR DESCRIPTION
## Summary

Branch-aware plugin coverage now reaches 94%, replacing placeholder assertions with behavioral tests for every module entry point and the shared Healthchecks.io client. Codecov collection is explicit in the unit matrix, and the project status now enforces a 90% floor instead of reporting informationally.

| Metric | Before | After |
| --- | ---: | ---: |
| Fresh all-source branch coverage | 23% | 94% |
| Unit tests | 10 | 93 |
| Module entry points above 90% | 1 of 8 | 8 of 8 |

## What Changed

- Cover response parsing, authentication failures, URL and HTTP dispatch, timeout forwarding, and ping-token fallback.
- Exercise info filtering, API error paths, unique-check matching, channel resolution, idempotency, check mode, create/update payloads, pause, and delete outcomes.
- Replace 6 placeholder module tests with dispatch and argument-spec assertions.
- Fix legacy Python invalid-JSON handling by catching the portable `ValueError` raised by the response parser.
- Collect coverage explicitly on every unit matrix run and require Codecov project coverage of at least 90%.

## Validation

- Black: passing
- Ansible sanity: passing
- Unit tests: 93 passing on Python 3.12
- Clean-tree branch coverage: 94% with branch tracking
- Workflow and Codecov YAML: parsed successfully
- Hosted integration workflows: passing against both the live service and self-hosted Docker stack

Closes ansible-collections/community.healthchecksio#62

## Post-Deploy Monitoring & Validation

Watch the Codecov project status and unit workflow for this PR and the first subsequent main-branch run. Healthy signals are a coverage upload attached to the current commit, project coverage at or above 90%, and a passing non-informational Codecov status. A missing upload, stale commit, or coverage below 90% is a failure signal and should block merging or trigger a revert of the coverage workflow/configuration change. Validation window: this PR plus the first main run. Owner: collection maintainers.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
