### PR TITLE
chore: prepare 1.5.4 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Community Healthchecks.io Release Notes
 
 .. contents:: Topics
 
+v1.5.4
+======
+
+Bugfixes
+--------
+
+- Handle invalid API error-response JSON on legacy Python versions without referencing the unavailable JSONDecodeError exception.
+
 v1.5.3
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -137,3 +137,11 @@ releases:
     fragments:
     - 58-ping-runid.yml
     release_date: '2026-07-31'
+  1.5.4:
+    changes:
+      bugfixes:
+      - Handle invalid API error-response JSON on legacy Python versions without referencing
+        the unavailable JSONDecodeError exception.
+    fragments:
+    - 62-legacy-json-error.yml
+    release_date: '2026-08-01'

--- a/changelogs/fragments/62-legacy-json-error.yml
+++ b/changelogs/fragments/62-legacy-json-error.yml
@@ -1,4 +1,0 @@
-bugfixes:
-  - >-
-    Handle invalid API error-response JSON on legacy Python versions without
-    referencing the unavailable JSONDecodeError exception.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: healthchecksio
-version: 1.5.4-dev0
+version: 1.5.4
 readme: README.md
 authors:
   - Mark Mercado (https://github.com/mamercad)


### PR DESCRIPTION
## Summary

Prepare community.healthchecksio 1.5.4 for publication after the coverage and legacy JSON compatibility work merged.

## Changes

- Set the collection version to 1.5.4.
- Generate the 1.5.4 changelog with antsibull-changelog.
- Consume the release fragment for the legacy Python invalid-JSON fix.

## Validation

- antsibull-changelog lint
- Release YAML parsing
- git diff --check
- Built community-healthchecksio-1.5.4.tar.gz
- Installed the built artifact and verified embedded version 1.5.4

## Post-Deploy Monitoring & Validation

After merge, push the plain 1.5.4 tag and watch the Ansible Zuul release pipeline. Confirm the version appears on Galaxy, install it from Galaxy, then create the matching GitHub release. A failed Zuul job or missing Galaxy version blocks completion and requires tag retry according to RELEASE.md.