### PR TITLE
chore: bump development version to 1.5.5-dev0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: healthchecksio
-version: 1.5.4
+version: 1.5.5-dev0
 readme: README.md
 authors:
   - Mark Mercado (https://github.com/mamercad)


### PR DESCRIPTION
## Summary

Advance the collection metadata to the next development version after publishing 1.5.4.

## Validation

- galaxy.yml parses successfully
- Version is exactly 1.5.5-dev0
- git diff --check passes

## Post-Deploy Monitoring & Validation

Confirm main reports 1.5.5-dev0 after merge and that no release tag is created for this development version.