### PR TITLE
feat: add Healthchecks.io API v3 parity

### DIFF
--- a/.agents/skills/release-healthchecksio/SKILL.md
+++ b/.agents/skills/release-healthchecksio/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: release-healthchecksio
+description: Merge, publish, and verify community.healthchecksio collection releases. Use in this repository when asked to merge a release-ready PR, cut or publish a release, monitor Ansible Zuul, verify Ansible Galaxy, create the GitHub release, close linked issues, or perform the post-release development-version bump.
+---
+
+# Release Healthchecks.io
+
+Follow `RELEASE.md` as the authoritative runbook. Complete the whole lifecycle; do not stop after merging, tagging, or creating a GitHub release.
+
+## Invariants
+
+- Publish only from `ansible-collections/community.healthchecksio`.
+- Require a clean worktree and a fully green current PR SHA before merging.
+- Use a plain annotated `X.Y.Z` tag. Never prefix the tag with `v`.
+- Let Ansible Zuul publish the `community` namespace artifact. Never run `ansible-galaxy collection publish` and never add a repository publication workflow.
+- Generate and consume changelog fragments in a release-preparation PR before tagging.
+- Create the GitHub release only after Galaxy lists and installs the version.
+- Do not treat intentionally skipped duplicate `pull_request_target` jobs as failures.
+- Preserve user work and use explicit force-with-lease protection if a reviewed branch must be rewritten.
+
+## 1. Establish The Release
+
+1. Read `RELEASE.md`, `galaxy.yml`, the pending changelog fragments, and the latest release.
+2. Derive the release version from the development version unless the user supplied one. For `X.Y.Z-dev0`, release `X.Y.Z`.
+3. Inspect the target PR, linked issues, mergeability, review state, head SHA, and every check.
+4. Refresh the check state immediately before merge. Stop for failures, pending required checks, unresolved review feedback, or a dirty worktree.
+
+## 2. Merge The Feature PR
+
+1. Merge using the repository's normal merge-commit strategy and delete the remote feature branch.
+2. Fetch `origin`, switch to `main`, and fast-forward to the exact remote merge commit.
+3. Verify the PR is merged and the expected files, fragment, development version, and skill are present on `main`.
+4. Close linked issues only when the merged work fully satisfies them and GitHub did not close them automatically.
+
+## 3. Prepare The Release
+
+1. Create `release/X.Y.Z` from current `origin/main`.
+2. Change `galaxy.yml` from `X.Y.Z-dev0` to `X.Y.Z`.
+3. Run:
+
+   ```bash
+   uv run antsibull-changelog lint
+   uv run antsibull-changelog release --version X.Y.Z
+   ```
+
+4. Confirm `CHANGELOG.rst` and `changelogs/changelog.yaml` contain the release, the release date is correct, and consumed fragments are deleted.
+5. Validate the release tree:
+
+   ```bash
+   git diff --check
+   uv run antsibull-changelog lint
+   ansible-galaxy collection build --force
+   ```
+
+6. Install the built tarball into a temporary isolated path and verify its embedded `galaxy.yml` version.
+7. Commit as `chore: prepare X.Y.Z release`, push, and open a release PR with summary, changelog, validation, and post-deploy verification.
+8. Wait for every required check, approve the protected integration environment when authorized, fix failures, and merge the release PR.
+
+## 4. Tag And Publish
+
+1. Fetch and verify `origin/main` contains the merged release PR and `galaxy.yml` says exactly `X.Y.Z`.
+2. Create the tag at that exact commit:
+
+   ```bash
+   git tag -a X.Y.Z <release-commit> -m "community.healthchecksio: X.Y.Z"
+   git push origin X.Y.Z
+   ```
+
+3. Monitor the Ansible Zuul release pipeline and poll the Galaxy v3 API until `X.Y.Z` appears:
+
+   ```text
+   https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/community/healthchecksio/versions/
+   ```
+
+4. If Zuul fails, follow the retry procedure in `RELEASE.md`. Recreate the same plain annotated tag at the same commit. Do not retry more than three times without escalating to Ansible community infrastructure.
+5. Install `community.healthchecksio:==X.Y.Z` from Galaxy into a fresh temporary path and verify the installed metadata version.
+
+## 5. Create The GitHub Release
+
+1. Create a non-draft, non-prerelease GitHub release using tag and title `X.Y.Z`.
+2. Summarize user-visible changes, call out breaking changes prominently, and link to the tagged `CHANGELOG.rst` section.
+3. Verify the release URL, tag target, publication state, and Galaxy availability.
+
+## 6. Restore Development State
+
+1. Select the next patch development version, normally `X.Y.(Z+1)-dev0`.
+2. Create `chore/bump-X.Y.(Z+1)-dev0` from current `origin/main`.
+3. Update only `galaxy.yml`, validate YAML, exact version, and `git diff --check`.
+4. Commit, push, open a PR, wait for required checks, and merge it.
+5. Verify `origin/main` now reports the development version and no release tag exists for it.
+
+## 7. Final Verification
+
+Do not report completion until fresh evidence confirms all of the following:
+
+- Feature PR and release PR are merged.
+- The plain annotated tag points to the release merge commit.
+- Galaxy lists and installs `X.Y.Z`.
+- The GitHub release is published and links to the tagged changelog.
+- Linked completed issues are closed.
+- The post-release bump PR is merged.
+- `origin/main` contains the next `-dev0` version.
+- Required checks on the final main commit are green.
+
+Report the feature PR, release PR, GitHub release, Galaxy version, post-release bump PR, final main version, and any intentionally skipped duplicate-event checks.

--- a/.agents/skills/release-healthchecksio/agents/openai.yaml
+++ b/.agents/skills/release-healthchecksio/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Release Healthchecks.io"
+  short_description: "Merge, publish, and verify collection releases"
+  default_prompt: "Use $release-healthchecksio to merge the ready PR, publish the collection release, verify Galaxy, and complete the post-release bump."

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This Ansible collection contains modules for assisting in the automation of the 
 From their site:
 > Healthchecks.io is an online service for monitoring regularly running tasks such as cron jobs. It uses the Dead man's switch technique: the monitored system must "check in" with Healthchecks.io at regular, configurable time intervals. When Healthchecks.io detects a missed check-in, it sends out alerts.
 
-The service documentation is located at [https://healthchecks.io/docs/](https://healthchecks.io/docs/) and the API documentation is located at [https://healthchecks.io/docs/api/](https://healthchecks.io/docs/api/). This Ansible module strives for API parity.
+The service documentation is located at [https://healthchecks.io/docs/](https://healthchecks.io/docs/) and the API documentation is located at [https://healthchecks.io/docs/api/](https://healthchecks.io/docs/api/). This collection strives for API parity. See the [API coverage matrix](docs/API_COVERAGE.md).
 
 ## Code of Conduct
 
@@ -96,13 +96,15 @@ N/A
 * `community.healthchecksio.badges_info` - Returns a map of all tags in the project, with badge URLs for each tag.
 * `community.healthchecksio.channels_info` - Returns a list of integrations belonging to the project.
 * `community.healthchecksio.checks_flips_info` - Get a list of check's status changes.
-* `community.healthchecksio.checks_info` - Returns a list of checks belonging to the user, optionally filtered by one or more tags.
+* `community.healthchecksio.checks_info` - Returns checks, optionally filtered by tags, slug, or read-only unique key.
 * `community.healthchecksio.checks_pings_info` - Returns a list of pings this check has received.
-* `community.healthchecksio.checks` - Create, delete, update, and pause checks.
+* `community.healthchecksio.checks_ping_body_info` - Returns the stored body for a logged ping.
+* `community.healthchecksio.checks` - Create, update, pause, resume, and delete checks.
+* `community.healthchecksio.status_info` - Checks service database connectivity.
 
 #### Ping API
 
-* `community.healthchecksio.ping` - Signal success, fail, and start events.
+* `community.healthchecksio.ping` - Signal success, failure, start, log, and process exit status events.
 
 ## Using this collection
 

--- a/changelogs/fragments/api-v3-parity.yml
+++ b/changelogs/fragments/api-v3-parity.yml
@@ -1,0 +1,17 @@
+---
+breaking_changes:
+  - The default management API base URL now targets Healthchecks.io API v3 instead of v1.
+  - checks - when both schedule and timeout are supplied, schedule now takes precedence; tz now requires schedule.
+  - checks_flips_info - uuid or unique_key is now required to identify the check.
+  - checks_pings_info - uuid is now required to identify the check.
+major_changes:
+  - The collection now defaults to Healthchecks.io Management API v3 and provides documented endpoint parity.
+minor_changes:
+  - checks - add explicit UUID updates, resume state, and all documented v3 keyword filtering fields.
+  - checks_flips_info - add read-only unique-key lookup and time filters.
+  - checks_info - add slug filtering and read-only unique-key lookup.
+  - checks_ping_body_info - add retrieval of stored ping request bodies.
+  - ping - add slug addressing, log events, diagnostic bodies, exit statuses, HTTP method selection, and automatic slug check creation.
+  - status_info - add the database connectivity status endpoint.
+bugfixes:
+  - API request payloads no longer include collection connection settings, and omitted check fields are no longer overwritten during explicit updates.

--- a/docs/API_COVERAGE.md
+++ b/docs/API_COVERAGE.md
@@ -1,0 +1,43 @@
+# Healthchecks.io API Coverage
+
+Last audited: 2026-08-01
+
+This collection targets the current [Management API v3](https://healthchecks.io/docs/api/) and [Pinging API](https://healthchecks.io/docs/http_api/). The default management base URL is `https://healthchecks.io/api/v3`; self-hosted installations can override it with `management_api_base_url`.
+
+## Management API v3
+
+| API operation | Collection coverage |
+| --- | --- |
+| List checks; filter by slug or repeated tags | `checks_info` |
+| Get a check by UUID or read-only `unique_key` | `checks_info` |
+| Create a simple, cron, or systemd `OnCalendar` check | `checks` with `state: present` |
+| Upsert by name, slug, tags, timeout, or grace | `checks` with `unique` |
+| Update a specific check | `checks` with `state: present` and `uuid` |
+| Configure integrations and all documented keyword filters | `checks` |
+| Pause monitoring | `checks` with `state: pause` |
+| Resume monitoring | `checks` with `state: resume` |
+| Delete a check | `checks` with `state: absent` |
+| List logged pings | `checks_pings_info` |
+| Get a logged ping body | `checks_ping_body_info` |
+| List status flips by UUID or `unique_key` | `checks_flips_info` |
+| Filter flips by seconds or UNIX timestamp range | `checks_flips_info` |
+| List integrations | `channels_info` |
+| List project badges | `badges_info` |
+| Check database connectivity | `status_info` |
+
+## Pinging API
+
+| API operation | Collection coverage |
+| --- | --- |
+| Identify checks by UUID | `ping.uuid` |
+| Identify checks by project ping key and slug | `ping.slug` and `ping_api_token` |
+| Send success, start, failure, and log events | `ping.signal` |
+| Report process exit status 0 through 255 | `ping.exit_status` |
+| Associate events using a run ID | `ping.runid` |
+| Store diagnostic request bodies | `ping.body` |
+| Select HEAD, GET, or POST | `ping.method` |
+| Automatically create a missing slug check | `ping.create` |
+
+## Verification
+
+Endpoint behavior is covered by unit tests, Ansible module validation, and the `api_v3` integration target against both Healthchecks.io and the repository's self-hosted Healthchecks container. When the upstream API documentation changes, update this matrix, the corresponding module documentation, and integration coverage in the same pull request.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: healthchecksio
-version: 1.5.5-dev0
+version: 2.0.0-dev0
 readme: README.md
 authors:
   - Mark Mercado (https://github.com/mamercad)

--- a/plugins/doc_fragments/healthchecksio.py
+++ b/plugins/doc_fragments/healthchecksio.py
@@ -26,10 +26,10 @@ options:
       - Base URL of the Healthchecks.io management API.
       - "There are several environment variables which can be used to provide this value:"
       - C(HEALTHCHECKSIO_API_MANAGEMENT_BASE_URL), C(HC_API_MANAGEMENT_BASE_URL)
-      - Defaults to C(https://healthchecks.io/api/v1).
+      - Defaults to C(https://healthchecks.io/api/v3).
     type: str
     required: false
-    default: https://healthchecks.io/api/v1
+    default: https://healthchecks.io/api/v3
   ping_api_base_url:
     description:
       - Base URL of the Healthchecks.io ping API.
@@ -41,7 +41,7 @@ options:
     default: https://hc-ping.com
   ping_api_token:
     description:
-      - Healthchecks.io ping API token (optional, can be used instead of management_api_token).
+      - Healthchecks.io project ping key. Required when pinging a check by slug.
       - "There are several environment variables which can be used to provide this value:"
       - C(HEALTHCHECKSIO_API_PING_KEY), C(HC_API_PING_KEY)
     type: str

--- a/plugins/module_utils/healthchecksio.py
+++ b/plugins/module_utils/healthchecksio.py
@@ -13,8 +13,13 @@ try:
 except ImportError:
     from urllib import quote
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils.common.text.converters import to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.basic import env_fallback
+
+DEFAULT_REQUEST_TIMEOUT = 30
+DEFAULT_PING_SIGNAL = "success"
+DEFAULT_PING_METHOD = "HEAD"
+DEFAULT_PING_CREATE = False
 
 
 class Response(object):
@@ -40,20 +45,29 @@ class Response(object):
             return None
 
     @property
+    def text(self):
+        if self.body is not None:
+            return to_text(self.body)
+        if "body" in self.info:
+            return to_text(self.info["body"])
+        return None
+
+    @property
     def status_code(self):
         return self.info["status"]
 
 
 class HealthchecksioHelper:
-    def __init__(self, module):
+    def __init__(self, module, authenticate=True):
         self.module = module
         self.base_url = self._get_base_url(module)
         self.api_token = self._get_api_token(module)
-        self.request_timeout = module.params.get("request_timeout", 30)
-        self.headers = {"X-Api-Key": self.api_token}
+        self.request_timeout = module.params.get(
+            "request_timeout", DEFAULT_REQUEST_TIMEOUT
+        )
+        self.headers = {"X-Api-Key": self.api_token} if self.api_token else {}
 
-        response = self.get("checks")
-        if response.status_code == 401:
+        if authenticate and self.get("checks").status_code == 401:
             self.module.fail_json(
                 msg="Failed to login using API token against {0}".format(self.base_url)
             )
@@ -71,11 +85,8 @@ class HealthchecksioHelper:
 
     def send(self, method, path, data=None):
         url = self._url_builder(path)
-        data = self.module.jsonify(data)
-
-        if method == "DELETE":
-            if data == "null":
-                data = None
+        if data is not None:
+            data = self.module.jsonify(data)
 
         resp, info = fetch_url(
             self.module,
@@ -99,27 +110,6 @@ class HealthchecksioHelper:
 
     def delete(self, path, data=None):
         return self.send("DELETE", path, data)
-
-    def head(self, path, data=None, no_headers=False):
-        uri = "{0}/{1}".format(self.base_url, path)
-        if no_headers is True:
-            resp, info = fetch_url(
-                self.module,
-                uri,
-                data=data,
-                method="HEAD",
-                timeout=self.request_timeout,
-            )
-        else:
-            resp, info = fetch_url(
-                self.module,
-                uri,
-                data=data,
-                headers=self.headers,
-                method="HEAD",
-                timeout=self.request_timeout,
-            )
-        return Response(resp, info)
 
     @staticmethod
     def healthchecksio_argument_spec():
@@ -157,7 +147,7 @@ class HealthchecksioHelper:
                 ),
                 required=False,
                 no_log=False,
-                default="https://healthchecks.io/api/v1",
+                default="https://healthchecks.io/api/v3",
             ),
             ping_api_base_url=dict(
                 type="str",
@@ -185,19 +175,33 @@ class HealthchecksioHelper:
                 no_log=True,
             ),
             validate_certs=dict(type="bool", default=True),
-            request_timeout=dict(type="int", default=30),
+            request_timeout=dict(type="int", default=DEFAULT_REQUEST_TIMEOUT),
         )
 
 
 class HealthchecksioPingHelper(HealthchecksioHelper):
+    def __init__(self, module):
+        super(HealthchecksioPingHelper, self).__init__(module, authenticate=False)
+
     def _get_api_token(self, module):
-        # We can use the management API token instead of the ping token
-        if module.params.get("ping_api_token") != "":
-            return module.params.get("ping_api_token")
-        return module.params.get("management_api_token")
+        return module.params.get("ping_api_token")
 
     def _get_base_url(self, module):
         return module.params.get("ping_api_base_url")
+
+    def ping(self, method, path, data=None):
+        if data is not None:
+            data = to_bytes(data)
+        headers = {"Content-Type": "text/plain; charset=utf-8"} if data else None
+        resp, info = fetch_url(
+            self.module,
+            self._url_builder(path),
+            data=data,
+            headers=headers,
+            method=method,
+            timeout=self.request_timeout,
+        )
+        return Response(resp, info)
 
 
 class BadgesInfo(object):
@@ -256,8 +260,17 @@ class ChecksFlipsInfo(object):
         self.rest = HealthchecksioHelper(module)
 
     def get(self):
-        uuid = self.module.params.get("uuid", None)
-        endpoint = "checks/{0}/flips".format(uuid)
+        identifier = self.module.params.get("unique_key") or self.module.params.get(
+            "uuid"
+        )
+        endpoint = "checks/{0}/flips".format(identifier)
+        query = []
+        for name in ("seconds", "start", "end"):
+            value = self.module.params.get(name)
+            if value is not None:
+                query.append("{0}={1}".format(name, value))
+        if query:
+            endpoint += "?" + "&".join(query)
 
         response = self.rest.get(endpoint)
         json_data = response.json
@@ -278,23 +291,21 @@ class ChecksInfo(object):
         self.rest = HealthchecksioHelper(module)
 
     def get(self):
-        endpoint = "checks"
+        identifier = self.module.params.get("unique_key") or self.module.params.get(
+            "uuid"
+        )
+        endpoint = "checks/{0}".format(identifier) if identifier else "checks"
 
-        tags = self.module.params.get("tags", None)
-        if tags is not None:
-            tags = ["tag=" + tag for tag in tags]
-            tags = "&".join(tags)
-            if tags:
-                endpoint += "?" + tags
-
-        uuid = self.module.params.get("uuid", None)
-        if uuid is not None:
-            endpoint += "/" + uuid
-
-        name = self.module.params.get("name", None)
-        if name is not None:
-            separator = "&" if "?" in endpoint else "?"
-            endpoint += separator + "name=" + quote(name, safe="")
+        if not identifier:
+            query = []
+            for tag in self.module.params.get("tags") or []:
+                query.append("tag=" + quote(tag, safe=""))
+            for name in ("slug", "name"):
+                value = self.module.params.get(name)
+                if value is not None:
+                    query.append("{0}={1}".format(name, quote(value, safe="")))
+            if query:
+                endpoint += "?" + "&".join(query)
 
         response = self.rest.get(endpoint)
         json_data = response.json
@@ -335,12 +346,54 @@ class ChecksPingsInfo(object):
         self.module.exit_json(changed=False, data=json_data)
 
 
+class ChecksPingBodyInfo(object):
+    def __init__(self, module):
+        self.module = module
+        self.rest = HealthchecksioHelper(module)
+
+    def get(self):
+        uuid = self.module.params.get("uuid")
+        sequence = self.module.params.get("sequence")
+        endpoint = "checks/{0}/pings/{1}/body".format(uuid, sequence)
+        response = self.rest.get(endpoint)
+
+        if response.status_code != 200:
+            self.module.fail_json(
+                changed=False,
+                msg="Failed to get {0} [HTTP {1}]".format(
+                    endpoint, response.status_code
+                ),
+            )
+
+        self.module.exit_json(changed=False, data=response.text)
+
+
+class StatusInfo(object):
+    def __init__(self, module):
+        self.module = module
+        self.rest = HealthchecksioHelper(module, authenticate=False)
+
+    def get(self):
+        response = self.rest.get("status/")
+        if response.status_code != 200:
+            self.module.fail_json(
+                changed=False,
+                msg="Healthchecks.io service status check failed [HTTP {0}]".format(
+                    response.status_code
+                ),
+            )
+        self.module.exit_json(changed=False, status="ok")
+
+
 class Checks(object):
     def __init__(self, module):
         self.module = module
         self.rest = HealthchecksioHelper(module)
 
     def get_uuid(self, json_data):
+        uuid = json_data.get("uuid")
+        if uuid:
+            return uuid
         ping_url = json_data.get("ping_url", None)
         if ping_url is not None:
             uuid = ping_url.split("/")[-1]
@@ -351,157 +404,120 @@ class Checks(object):
         else:
             return "(unable to determine uuid)"
 
+    def _resolve_channels(self, request_params):
+        channels_param = request_params.get("channels")
+        cache = getattr(self, "_resolved_channels", {})
+        if channels_param not in cache:
+            if channels_param == "*":
+                channels = self.rest.get("channels").json.get("channels", [])
+                cache[channels_param] = ",".join(channel["id"] for channel in channels)
+            else:
+                cache[channels_param] = channels_param
+            self._resolved_channels = cache
+        return cache[channels_param]
+
+    def _matches(self, check, request_params):
+        skip = set(["unique", "channels", "tags"])
+        params_match = all(
+            check.get(key) == value
+            for key, value in request_params.items()
+            if key not in skip
+        )
+        if not params_match:
+            return False
+
+        if "channels" in request_params:
+            expected = self._resolve_channels(request_params) or ""
+            actual = check.get("channels", "")
+            if sorted(actual.split(",")) != sorted(expected.split(",")):
+                return False
+
+        if "tags" in request_params and check.get("tags", "") != request_params["tags"]:
+            return False
+
+        return True
+
     def _find_existing_check(self, request_params):
-        # Build the tags string as the API does
-        tags = self.module.params.get("tags", [])
-        tags_str = " ".join(tags)
+        unique = request_params.get("unique", [])
+        if not unique:
+            return None
 
         checks = self.rest.get("checks").json["checks"]
-        unique = request_params.get("unique", [])
-        c = [
+        matches = [
             check
             for check in checks
-            if all(check.get(k) == request_params.get(k) for k in unique)
+            if all(check.get(key) == request_params.get(key) for key in unique)
         ]
 
-        if len(c) > 1 and len(unique) != 0:
+        if len(matches) > 1 and unique:
             self.module.fail_json(
                 changed=False,
                 msg="Expected to find one check matching unique parameters, {0} found".format(
-                    len(c)
+                    len(matches)
                 ),
             )
 
-        # Resolve "*" channels to actual channel IDs
-        channels_param = request_params.get("channels", "")
-        if channels_param == "*":
-            channels = self.rest.get("channels").json.get("channels", [])
-            channels_ids = [ch["id"] for ch in channels]
-            channels_str = ",".join(channels_ids)
-        else:
-            channels_str = channels_param
-
-        if len(c) == 1:
-            # Check if params match (excluding unique/api_key/channels/grace)
-            skip = set(
-                [
-                    "unique",
-                    "api_key",
-                    "management_api_key",
-                    "management_api_token",
-                    "management_api_base_url",
-                    "ping_api_key",
-                    "ping_api_base_url",
-                    "ping_api_token",
-                    "validate_certs",
-                    "request_timeout",
-                    "channels",
-                    "tags",
-                    "grace",  # API may return None, module defaults to 3600
-                ]
-            )
-            params_match = all(
-                c[0].get(k) == request_params.get(k)
-                for k in request_params
-                if k not in skip
-            )
-            channels_match = sorted(c[0].get("channels", "").split(",")) == sorted(
-                channels_str.split(",")
-            )
-            tags_match = c[0].get("tags", "") == tags_str
-            if params_match and channels_match and tags_match:
-                return c[0]
+        if len(matches) == 1 and self._matches(matches[0], request_params):
+            return matches[0]
         return None
 
     def create(self):
-        endpoint = "checks/"
+        uuid = self.module.params.get("uuid")
+        endpoint = "checks/{0}".format(uuid) if uuid else "checks/"
 
         request_params = dict(self.module.params)
 
-        # uuid is not used to create or update
-        request_params.pop("uuid", None)
-        request_params.pop("state", None)
-        request_params.pop("validate_certs", None)
-        request_params.pop("request_timeout", None)
+        for key in (
+            "uuid",
+            "state",
+            "api_key",
+            "management_api_key",
+            "management_api_token",
+            "management_api_base_url",
+            "ping_api_token",
+            "ping_api_base_url",
+            "validate_certs",
+            "request_timeout",
+        ):
+            request_params.pop(key, None)
+        request_params = dict(
+            (key, value) for key, value in request_params.items() if value is not None
+        )
 
-        # if schedule and tz, create a Cron check
-        if request_params.get("schedule") and request_params.get("tz"):
-            del request_params["timeout"]
+        if uuid:
+            request_params.pop("unique", None)
 
-        # if timeout, create a Simple check
-        if request_params.get("timeout"):
-            del request_params["schedule"]
-            del request_params["tz"]
+        if request_params.get("schedule"):
+            request_params.pop("timeout", None)
+        elif request_params.get("timeout"):
+            request_params.pop("schedule", None)
+            request_params.pop("tz", None)
 
-        tags = self.module.params.get("tags", [])
-        request_params["tags"] = " ".join(tags)
+        if "tags" in request_params:
+            request_params["tags"] = " ".join(request_params["tags"])
 
-        # Look up existing check for idempotency
-        existing = self._find_existing_check(request_params)
-
+        # Look up existing check for idempotency. UUID selects the explicit
+        # update endpoint; otherwise the API's upsert fields identify a check.
+        if uuid:
+            response = self.rest.get("checks/{0}".format(uuid))
+            existing = response.json if response.status_code == 200 else None
+            matches = existing is not None and self._matches(existing, request_params)
+        else:
+            existing = self._find_existing_check(request_params)
+            matches = existing is not None
         if self.module.check_mode:
-            if existing is not None:
-                self.module.exit_json(
-                    changed=False,
-                    data=existing,
-                    uuid=self.get_uuid(existing),
-                )
-            else:
-                self.module.exit_json(
-                    changed=True,
-                    data={},
-                    uuid="",
-                )
-
-        if existing is not None:
-            # Extract "*" channels for comparison
-            channels_param = request_params.get("channels", "")
-            if channels_param == "*":
-                channels = self.rest.get("channels").json.get("channels", [])
-                channels_ids = [ch["id"] for ch in channels]
-                channels_str = ",".join(channels_ids)
-            else:
-                channels_str = channels_param
-
-            before = existing
-            channels_match = sorted(before.get("channels", "").split(",")) == sorted(
-                channels_str.split(",")
+            self.module.exit_json(
+                changed=not matches,
+                data=existing if matches else {},
+                uuid=self.get_uuid(existing) if matches else "",
             )
-            skip_idempotency_params = [
-                "unique",
-                "api_key",
-                "management_api_key",
-                "management_api_token",
-                "management_api_base_url",
-                "ping_api_key",
-                "ping_api_base_url",
-                "ping_api_token",
-                "validate_certs",
-                "request_timeout",
-                "channels",
-                "tags",
-                # grace: API may return None, module defaults to 3600
-                "grace",
-                # desc: API returns "", module params has None (no default in spec)
-                "desc",
-            ]
-            params_match = all(
-                before.get(k) == request_params.get(k)
-                for k in request_params
-                if k not in skip_idempotency_params
+
+        if matches:
+            self.module.exit_json(
+                changed=False,
+                data=existing,
+                uuid=self.get_uuid(existing),
             )
-            tags_match = before.get("tags", "") == request_params.get("tags")
-            if params_match and channels_match and tags_match:
-                diff = (
-                    dict(before=before, after=before)
-                    if getattr(self.module, "diff_mode", False)
-                    else None
-                )
-                self.module.exit_json(
-                    changed=False,
-                    data=before,
-                    uuid=self.get_uuid(before),
-                )
 
         response = self.rest.post(endpoint, data=request_params)
         json_data = response.json
@@ -509,12 +525,6 @@ class Checks(object):
 
         if status_code == 200:
             uuid = self.get_uuid(json_data)
-            after = json_data
-            diff = (
-                dict(before=existing, after=after)
-                if getattr(self.module, "diff_mode", False)
-                else None
-            )
             self.module.exit_json(
                 changed=True,
                 msg="Existing check {0} found and updated".format(uuid),
@@ -524,11 +534,6 @@ class Checks(object):
 
         elif status_code == 201:
             uuid = self.get_uuid(json_data)
-            diff = (
-                dict(before={}, after=json_data)
-                if getattr(self.module, "diff_mode", False)
-                else None
-            )
             self.module.exit_json(
                 changed=True,
                 msg="New check {0} created".format(uuid),
@@ -596,39 +601,86 @@ class Checks(object):
                 msg="Failed to pause check {0} [HTTP {1}]".format(uuid, status_code),
             )
 
+    def resume(self):
+        uuid = self.module.params.get("uuid")
+        endpoint = "checks/{0}/resume".format(uuid)
+
+        if self.module.check_mode:
+            self.module.exit_json(
+                changed=True,
+                msg="Check {0} would be resumed".format(uuid),
+                uuid=uuid,
+            )
+
+        response = self.rest.post(endpoint)
+        status_code = response.status_code
+
+        if status_code == 200:
+            self.module.exit_json(
+                changed=True, msg="Check {0} successfully resumed".format(uuid)
+            )
+        elif status_code == 404:
+            self.module.exit_json(changed=False, msg="Check {0} not found".format(uuid))
+        elif status_code == 409:
+            self.module.exit_json(
+                changed=False, msg="Check {0} is not paused".format(uuid)
+            )
+        else:
+            self.module.fail_json(
+                changed=False,
+                msg="Failed to resume check {0} [HTTP {1}]".format(uuid, status_code),
+            )
+
 
 class Ping(object):
     def __init__(self, module):
         self.module = module
         self.rest = HealthchecksioPingHelper(module)
 
-    def create(self, uuid, signal, runid=None):
+    def create(
+        self,
+        uuid=None,
+        signal=DEFAULT_PING_SIGNAL,
+        runid=None,
+        slug=None,
+        body=None,
+        method=DEFAULT_PING_METHOD,
+        create=DEFAULT_PING_CREATE,
+        exit_status=None,
+    ):
         if self.module.check_mode:
             self.module.exit_json(changed=False, data={})
 
-        if signal == "success":
+        target = slug if slug is not None else uuid
+        if slug is not None:
+            endpoint = "{0}/{1}".format(self.rest.api_token, slug)
+        else:
             endpoint = "{0}".format(uuid)
-        else:
-            endpoint = "{0}/{1}".format(uuid, signal)
 
-        request_endpoint = endpoint
+        event = str(exit_status) if exit_status is not None else signal
+        if event != "success":
+            endpoint = "{0}/{1}".format(endpoint, event)
+
+        query = []
         if runid is not None:
-            request_endpoint = "{0}?rid={1}".format(
-                request_endpoint, quote(runid, safe="")
-            )
+            query.append("rid={0}".format(quote(runid, safe="")))
+        if create:
+            query.append("create=1")
+        request_endpoint = endpoint
+        if query:
+            request_endpoint = "{0}?{1}".format(endpoint, "&".join(query))
 
-        response = self.rest.head(request_endpoint, no_headers=True)
-        status_code = response.status_code
+        if body is not None and method == "HEAD":
+            method = "POST"
+        response = self.rest.ping(method, request_endpoint, data=body)
 
-        if status_code == 200:
+        if response.status_code in (200, 201):
             self.module.exit_json(
-                changed=True, msg="Sent {0} signal to {1}".format(signal, endpoint)
+                changed=True, msg="Sent {0} signal to {1}".format(event, target)
             )
-
-        else:
-            self.module.fail_json(
-                changed=False,
-                msg="Failed to send {0} signal to {1} [HTTP {2}]".format(
-                    signal, endpoint, status_code
-                ),
-            )
+        self.module.fail_json(
+            changed=False,
+            msg="Failed to send {0} signal to {1} [HTTP {2}]".format(
+                event, target, response.status_code
+            ),
+        )

--- a/plugins/modules/checks.py
+++ b/plugins/modules/checks.py
@@ -11,11 +11,13 @@ __metaclass__ = type
 DOCUMENTATION = r"""
 ---
 module: checks
-short_description: Create, delete, update, and pause checks
+short_description: Create, update, pause, resume, and delete checks
 description:
   - Creates a new check and returns its ping URL.
   - For C(state=absent), will delete the check with the given C(uuid).
   - For C(state=pause), will pause the check with the given C(uuid).
+  - For C(state=resume), will resume the check with the given C(uuid).
+  - Set C(uuid) with C(state=present) to update a specific existing check.
   - All request parameters are optional and will use their default values if omitted.
   - To create a Simple check, specify the C(timeout) parameter.
   - To create a Cron check, specify the C(schedule) and C(tz) parameters.
@@ -27,32 +29,30 @@ options:
       - C(present) will create or update a check.
       - C(absent) will delete a check.
       - C(pause) will pause a check.
+      - C(resume) will resume a paused check.
     type: str
-    choices: ["present", "absent", "pause"]
+    choices: ["present", "absent", "pause", "resume"]
     default: present
   name:
     description:
       - Name for the new check.
     type: str
     required: false
-    default: ""
   tags:
     description:
       - Tags for the check.
     type: list
     elements: str
     required: false
-    default: []
   desc:
     description:
       - Description of the check.
     type: str
     required: false
-    default: ""
   timeout:
     description:
       - A number of seconds, the expected period of this check.
-      - Minimum 60 (one minute), maximum 2592000 (30 days).
+      - Minimum 60 (one minute), maximum 31536000 (365 days).
     type: int
     required: false
   grace:
@@ -60,11 +60,10 @@ options:
       - A number of seconds, the grace period for this check.
     type: int
     required: false
-    default: 3600
   schedule:
     description:
-      - A cron expression defining this check's schedule.
-      - If you specify both timeout and schedule parameters, Healthchecks.io will create a Cron check and ignore the timeout value.
+      - A cron or systemd OnCalendar expression defining this check's schedule.
+      - If both C(timeout) and C(schedule) are specified, C(schedule) takes precedence.
     type: str
     required: false
   tz:
@@ -79,7 +78,6 @@ options:
       - If set to true, a paused check will ignore pings and stay paused until you manually resume it from the web dashboard.
     type: bool
     required: false
-    default: false
   methods:
     description:
       - Specifies the allowed HTTP methods for making ping requests.
@@ -87,8 +85,8 @@ options:
       - Set this field to "" (an empty string) to allow HEAD, GET, and POST requests.
       - Set this field to "POST" to allow only POST requests.
     type: str
+    choices: ["", "POST"]
     required: false
-    default: ""
   channels:
     description:
       - By default, this API call assigns no integrations to the newly created check.
@@ -96,28 +94,54 @@ options:
       - To assign specific integrations, use a comma-separated list of integration UUIDs.
     type: str
     required: false
-    default: ""
   unique:
     description:
-      - Enables "upsert" functionality.
-      - Before creating a check, Healthchecks.io looks for existing checks, filtered by fields listed in unique.
-      - The accepted values for the unique field are C(name), C(tags), C(timeout), and C(grace).
+      - Enables upsert functionality when C(uuid) is not specified.
+      - Before creating a check, Healthchecks.io looks for existing checks, filtered by fields listed in C(unique).
+      - Accepted values are C(name), C(slug), C(tags), C(timeout), and C(grace).
     type: list
     elements: str
+    choices: [name, slug, tags, timeout, grace]
     required: false
-    default: []
+  start_kw:
+    description:
+      - Comma-separated, case-sensitive keywords that classify pings as start signals.
+    type: str
+  success_kw:
+    description:
+      - Comma-separated, case-sensitive keywords that classify pings as success signals.
+    type: str
+  failure_kw:
+    description:
+      - Comma-separated, case-sensitive keywords that classify pings as failure signals.
+    type: str
+  filter_subject:
+    description:
+      - Look for signal keywords in inbound email subject lines.
+    type: bool
+  filter_body:
+    description:
+      - Look for signal keywords in inbound email bodies.
+    type: bool
+  filter_http_body:
+    description:
+      - Look for signal keywords in HTTP ping request bodies.
+    type: bool
+  filter_default_fail:
+    description:
+      - Classify unmatched messages as failures when keyword filtering is enabled.
+    type: bool
   uuid:
     description:
-      - Check uuid to delete when state is C(absent) or C(pause).
+      - Check UUID to update, delete, pause, or resume.
+      - When set with C(state=present), the module uses the explicit update endpoint.
     type: str
     required: false
-    default: ""
   slug:
     description:
       - Optional slug for the check URL.
     type: str
     required: false
-    default: ""
 extends_documentation_fragment:
   - community.healthchecksio.healthchecksio.documentation
 """
@@ -141,6 +165,11 @@ EXAMPLES = r"""
     desc: "my hourly test check"
     schedule: "0 * * * *"
     tz: UTC
+
+- name: Resume a manually paused check
+  community.healthchecksio.checks:
+    state: resume
+    uuid: "{{ check_uuid }}"
 """
 
 RETURN = r"""
@@ -158,14 +187,14 @@ data:
     n_pings: 0
     name: test
     next_ping: null
-    pause_url: https://healthchecks.io/api/v1/checks/524d0f69-0ff3-4120-a2e2-03ebd5736b25/pause
+    pause_url: https://healthchecks.io/api/v3/checks/524d0f69-0ff3-4120-a2e2-03ebd5736b25/pause
     ping_url: https://hc-ping.com/524d0f69-0ff3-4120-a2e2-03ebd5736b25
     schedule: '* * * * *'
     slug: test
     status: new
     tags: ''
     tz: UTC
-    update_url: https://healthchecks.io/api/v1/checks/524d0f69-0ff3-4120-a2e2-03ebd5736b25
+    update_url: https://healthchecks.io/api/v3/checks/524d0f69-0ff3-4120-a2e2-03ebd5736b25
 msg:
   description: Create, update, pause or delete message
   returned: always
@@ -194,34 +223,52 @@ def run(module):
         checks.delete()
     elif state == "pause":
         checks.pause()
+    elif state == "resume":
+        checks.resume()
 
 
 def main():
     argument_spec = HealthchecksioHelper.healthchecksio_argument_spec()
     argument_spec.update(
         state=dict(
-            type="str", choices=["present", "absent", "pause"], default="present"
+            type="str",
+            choices=["present", "absent", "pause", "resume"],
+            default="present",
         ),
-        name=dict(type="str", required=False, default=""),
-        tags=dict(type="list", elements="str", required=False, default=[]),
-        desc=dict(type="str", required=False, default=""),
-        timeout=dict(type="int", required=False),
-        grace=dict(type="int", required=False, default=3600),
-        schedule=dict(type="str", required=False),
-        tz=dict(type="str", required=False),
-        manual_resume=dict(type="bool", required=False, default=False),
-        methods=dict(type="str", required=False, default=""),
-        channels=dict(type="str", required=False, default=""),
-        unique=dict(type="list", elements="str", required=False, default=[]),
-        uuid=dict(type="str", required=False, default=""),
-        slug=dict(type="str", required=False, default=""),
+        name=dict(type="str"),
+        tags=dict(type="list", elements="str"),
+        desc=dict(type="str"),
+        timeout=dict(type="int"),
+        grace=dict(type="int"),
+        schedule=dict(type="str"),
+        tz=dict(type="str"),
+        manual_resume=dict(type="bool"),
+        methods=dict(type="str", choices=["", "POST"]),
+        channels=dict(type="str"),
+        unique=dict(
+            type="list",
+            elements="str",
+            choices=["name", "slug", "tags", "timeout", "grace"],
+        ),
+        uuid=dict(type="str"),
+        slug=dict(type="str"),
+        start_kw=dict(type="str"),
+        success_kw=dict(type="str"),
+        failure_kw=dict(type="str"),
+        filter_subject=dict(type="bool"),
+        filter_body=dict(type="bool"),
+        filter_http_body=dict(type="bool"),
+        filter_default_fail=dict(type="bool"),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_if=[("state", "absent", ["uuid"]), ("state", "pause", ["uuid"])],
-        required_together=[("schedule", "tz")],
-        mutually_exclusive=[("timeout", "schedule"), ("timeout", "tz")],
+        required_if=[
+            ("state", "absent", ["uuid"]),
+            ("state", "pause", ["uuid"]),
+            ("state", "resume", ["uuid"]),
+        ],
+        required_by={"tz": "schedule"},
     )
 
     run(module)

--- a/plugins/modules/checks_flips_info.py
+++ b/plugins/modules/checks_flips_info.py
@@ -27,9 +27,30 @@ options:
     default: present
   uuid:
     description:
-      - If specified, returns this specific check.
+      - Check UUID whose status changes to return.
     type: str
     required: false
+  unique_key:
+    description:
+      - Stable check identifier from a read-only API response.
+    type: str
+    required: false
+    version_added: 2.0.0
+  seconds:
+    description:
+      - Return flips from the last specified number of seconds.
+    type: int
+    version_added: 2.0.0
+  start:
+    description:
+      - Return flips newer than this UNIX timestamp.
+    type: int
+    version_added: 2.0.0
+  end:
+    description:
+      - Return flips older than this UNIX timestamp.
+    type: int
+    version_added: 2.0.0
 extends_documentation_fragment:
   - community.healthchecksio.healthchecksio.documentation
 """
@@ -39,15 +60,18 @@ EXAMPLES = r"""
   community.healthchecksio.checks_flips_info:
     state: present
     uuid: cae50618-c97f-483e-9814-0277dc523d1
+    seconds: 3600
 """
 
 RETURN = r"""
 data:
-  description: List of check flips
+  description: Check flips response
   returned: always
   type: dict
   sample:
-    flips: []
+    flips:
+      - timestamp: '2020-03-23T10:18:23+00:00'
+        up: 1
 """
 
 
@@ -70,8 +94,21 @@ def main():
     argument_spec.update(
         state=dict(type="str", choices=["present"], default="present"),
         uuid=dict(type="str", required=False),
+        unique_key=dict(type="str", required=False, no_log=False),
+        seconds=dict(type="int"),
+        start=dict(type="int"),
+        end=dict(type="int"),
     )
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_one_of=[("uuid", "unique_key")],
+        mutually_exclusive=[
+            ("uuid", "unique_key"),
+            ("seconds", "start"),
+            ("seconds", "end"),
+        ],
+    )
 
     run(module)
 

--- a/plugins/modules/checks_info.py
+++ b/plugins/modules/checks_info.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r"""
 module: checks_info
 short_description: Get a list of checks
 description:
-  - Returns a list of checks belonging to the user, optionally filtered by one or more tags.
+  - Returns checks, optionally filtered by slug or one or more tags.
 author: "Mark Mercado (@mamercad)"
 version_added: 0.1.0
 options:
@@ -31,7 +31,17 @@ options:
     required: false
   uuid:
     description:
-      - If specified, returns this specific check.
+      - If specified, returns this specific check by UUID.
+    type: str
+    required: false
+  unique_key:
+    description:
+      - If specified, returns a specific check by the stable identifier from read-only API responses.
+    type: str
+    required: false
+  slug:
+    description:
+      - Filters checks by their exact slug.
     type: str
     required: false
   name:
@@ -45,6 +55,13 @@ extends_documentation_fragment:
 """
 
 EXAMPLES = r"""
+- name: Get all checks tagged production
+  community.healthchecksio.checks_info:
+    tags: [production]
+
+- name: Get a check using a read-only API key identifier
+  community.healthchecksio.checks_info:
+    unique_key: "{{ check_unique_key }}"
 """
 
 RETURN = r"""
@@ -71,12 +88,22 @@ def main():
         state=dict(type="str", choices=["present"], default="present"),
         tags=dict(type="list", elements="str", required=False),
         uuid=dict(type="str", required=False),
+        unique_key=dict(type="str", required=False, no_log=False),
+        slug=dict(type="str", required=False),
         name=dict(type="str", required=False),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        mutually_exclusive=[("tags", "uuid"), ("name", "uuid")],
+        mutually_exclusive=[
+            ("uuid", "unique_key"),
+            ("uuid", "tags"),
+            ("uuid", "slug"),
+            ("uuid", "name"),
+            ("unique_key", "tags"),
+            ("unique_key", "slug"),
+            ("unique_key", "name"),
+        ],
     )
 
     run(module)

--- a/plugins/modules/checks_ping_body_info.py
+++ b/plugins/modules/checks_ping_body_info.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2026, Mark Mercado <mamercad@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: checks_ping_body_info
+short_description: Get a logged ping body
+description:
+  - Returns the stored request body for one logged ping as plain text.
+  - The API returns HTTP 404 when the check, ping, or body does not exist.
+author: "Mark Mercado (@mamercad)"
+version_added: 2.0.0
+options:
+  uuid:
+    description:
+      - UUID of the check that received the ping.
+    type: str
+    required: true
+  sequence:
+    description:
+      - Ping sequence number from the C(n) field returned by M(community.healthchecksio.checks_pings_info).
+    type: int
+    required: true
+extends_documentation_fragment:
+  - community.healthchecksio.healthchecksio.documentation
+"""
+
+EXAMPLES = r"""
+- name: Read a logged ping body
+  community.healthchecksio.checks_ping_body_info:
+    uuid: "{{ check_uuid }}"
+    sequence: 42
+  register: ping_body
+"""
+
+RETURN = r"""
+data:
+  description: Logged ping request body.
+  returned: success
+  type: str
+  sample: Backup completed successfully
+"""
+
+from ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio import (
+    ChecksPingBodyInfo,
+    HealthchecksioHelper,
+)
+from ansible.module_utils.basic import AnsibleModule
+
+
+def run(module):
+    ChecksPingBodyInfo(module).get()
+
+
+def main():
+    argument_spec = HealthchecksioHelper.healthchecksio_argument_spec()
+    argument_spec.pop("state", None)
+    argument_spec.update(
+        uuid=dict(type="str", required=True),
+        sequence=dict(type="int", required=True),
+    )
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    run(module)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/plugins/modules/checks_pings_info.py
+++ b/plugins/modules/checks_pings_info.py
@@ -29,7 +29,7 @@ options:
     description:
       - If specified, returns this specific check.
     type: str
-    required: false
+    required: true
 extends_documentation_fragment:
   - community.healthchecksio.healthchecksio.documentation
 """
@@ -76,7 +76,7 @@ def main():
     argument_spec = HealthchecksioHelper.healthchecksio_argument_spec()
     argument_spec.update(
         state=dict(type="str", choices=["present"], default="present"),
-        uuid=dict(type="str", required=False),
+        uuid=dict(type="str", required=True),
     )
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 

--- a/plugins/modules/ping.py
+++ b/plugins/modules/ping.py
@@ -7,79 +7,115 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-
 DOCUMENTATION = r"""
 ---
 module: ping
-short_description: Signal success, fail, and start events
+short_description: Send Healthchecks.io ping events
 description:
-  - With the Pinging API, you can signal success, fail, and start events from your systems.
+  - Signals success, failure, start, log, or process exit status events.
+  - Identifies a check by C(uuid), or by C(slug) together with the project C(ping_api_token).
+  - A request body is sent with HTTP POST and stored as diagnostic data by Healthchecks.io.
 author: "Mark Mercado (@mamercad)"
 version_added: 0.1.0
 options:
   state:
     description:
-      - C(present) will send a signal.
+      - C(present) sends the event.
     type: str
-    choices: ["present"]
+    choices: [present]
     default: present
   uuid:
     description:
-      - Check uuid to delete when state is C(absent) or C(pause).
+      - Immutable check UUID.
+      - Mutually exclusive with C(slug).
     type: str
-    required: true
+  slug:
+    description:
+      - Check slug. Requires the project ping key in C(ping_api_token).
+      - Mutually exclusive with C(uuid).
+    type: str
+    version_added: 2.0.0
   signal:
     description:
-      - Type of signal to send, C(success), C(fail) or C(start).
+      - Event type to send.
+      - C(log) stores diagnostic data without changing check status.
+      - Ignored when C(exit_status) is specified.
     type: str
-    choices: ["success", "fail", "start"]
+    choices: [success, fail, start, log]
     default: success
+  exit_status:
+    description:
+      - Process exit status from 0 through 255.
+      - Healthchecks.io interprets 0 as success and all other values as failure.
+    type: int
+    version_added: 2.0.0
   runid:
     description:
-      - Optional run ID to send in the Healthchecks.io C(rid) query parameter.
-      - Use the same run ID for matching C(start), C(success), and C(fail) pings from one job execution.
-      - Healthchecks.io requires this value to be a UUID in canonical textual representation.
+      - Optional run ID sent in the Healthchecks.io C(rid) query parameter.
+      - Use the same canonical UUID for matching start and completion pings from one execution.
     type: str
+    version_added: 1.5.0
+  body:
+    description:
+      - Optional diagnostic text to store with the ping.
+      - Supplying a body changes the default C(method) from C(HEAD) to C(POST).
+    type: str
+    version_added: 2.0.0
+  method:
+    description:
+      - HTTP method used for the ping request.
+      - C(GET) cannot be used together with C(body); use C(POST) instead.
+    type: str
+    choices: [HEAD, GET, POST]
+    default: HEAD
+    version_added: 2.0.0
+  create:
+    description:
+      - Automatically create a missing check when pinging by C(slug).
+      - Maps to the Pinging API C(create=1) query parameter.
+    type: bool
+    default: false
+    version_added: 2.0.0
 extends_documentation_fragment:
   - community.healthchecksio.healthchecksio.documentation
 """
 
 EXAMPLES = r"""
-- name: Send a success signal
+- name: Send a success signal by UUID
   community.healthchecksio.ping:
-    state: present
     uuid: "{{ check_uuid }}"
-    signal: success
 
-- name: Send a fail signal
+- name: Send a failure signal with diagnostic output
   community.healthchecksio.ping:
-    state: present
     uuid: "{{ check_uuid }}"
     signal: fail
+    body: "{{ job_stderr }}"
 
-- name: Send a start signal
+- name: Send a start signal by slug and run ID
   community.healthchecksio.ping:
-    state: present
-    uuid: "{{ check_uuid }}"
+    slug: database-backup
+    ping_api_token: "{{ project_ping_key }}"
     signal: start
+    runid: "{{ run_id }}"
 
-- name: Send a start signal with a run ID
+- name: Report a process exit status
   community.healthchecksio.ping:
-    state: present
     uuid: "{{ check_uuid }}"
-    signal: start
-    runid: "{{ ansible_date_time.iso8601_micro | to_uuid }}"
+    exit_status: "{{ command_result.rc }}"
 """
 
 RETURN = r"""
 msg:
-  description: Signal result message
-  returned: always
+  description: Event result message.
+  returned: success
   type: str
   sample: Sent success signal to 8597dcda-23d1-4e6b-b904-83df360bf8a8
 """
 
 from ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio import (
+    DEFAULT_PING_CREATE,
+    DEFAULT_PING_METHOD,
+    DEFAULT_PING_SIGNAL,
     HealthchecksioHelper,
     Ping,
 )
@@ -87,30 +123,63 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 def run(module):
-    state = module.params.pop("state")
-    uuid = module.params.pop("uuid")
-    signal = module.params.pop("signal")
-    runid = module.params.pop("runid")
+    params = dict(module.params)
+    state = params.pop("state")
+    if state != "present":
+        return
+
+    uuid = params.pop("uuid", None)
+    slug = params.pop("slug", None)
+    exit_status = params.pop("exit_status", None)
+    if slug and not params.get("ping_api_token"):
+        module.fail_json(msg="ping_api_token is required when slug is specified")
+    if params.get("create") and not slug:
+        module.fail_json(msg="create is only supported when slug is specified")
+    if exit_status is not None and not 0 <= exit_status <= 255:
+        module.fail_json(msg="exit_status must be between 0 and 255")
+    if params.get("body") is not None and params.get("method") == "GET":
+        module.fail_json(msg="body cannot be used with method=GET; use POST")
+
     ping = Ping(module)
-    if state == "present":
-        ping.create(uuid, signal, runid)
+    ping.create(
+        uuid=uuid,
+        slug=slug,
+        signal=params.pop("signal", DEFAULT_PING_SIGNAL),
+        runid=params.pop("runid", None),
+        body=params.pop("body", None),
+        method=params.pop("method", DEFAULT_PING_METHOD),
+        create=params.pop("create", DEFAULT_PING_CREATE),
+        exit_status=exit_status,
+    )
 
 
 def main():
     argument_spec = HealthchecksioHelper.healthchecksio_argument_spec()
     argument_spec.update(
         state=dict(type="str", choices=["present"], default="present"),
-        uuid=dict(type="str", required=True),
+        uuid=dict(type="str"),
+        slug=dict(type="str"),
         signal=dict(
             type="str",
-            choices=["success", "fail", "start"],
-            required=False,
-            default="success",
+            choices=["success", "fail", "start", "log"],
+            default=DEFAULT_PING_SIGNAL,
         ),
-        runid=dict(type="str", required=False),
+        exit_status=dict(type="int"),
+        runid=dict(type="str"),
+        body=dict(type="str"),
+        method=dict(
+            type="str",
+            choices=["HEAD", "GET", "POST"],
+            default=DEFAULT_PING_METHOD,
+        ),
+        create=dict(type="bool", default=DEFAULT_PING_CREATE),
     )
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_one_of=[("uuid", "slug")],
+        mutually_exclusive=[("uuid", "slug")],
+    )
     run(module)
 
 

--- a/plugins/modules/status_info.py
+++ b/plugins/modules/status_info.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2026, Mark Mercado <mamercad@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: status_info
+short_description: Check Healthchecks.io service status
+description:
+  - Runs the Management API database connectivity check.
+  - This endpoint does not require an API key.
+author: "Mark Mercado (@mamercad)"
+version_added: 2.0.0
+extends_documentation_fragment:
+  - community.healthchecksio.healthchecksio.documentation
+"""
+
+EXAMPLES = r"""
+- name: Verify Healthchecks.io database connectivity
+  community.healthchecksio.status_info:
+"""
+
+RETURN = r"""
+status:
+  description: Service status.
+  returned: success
+  type: str
+  sample: ok
+"""
+
+from ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio import (
+    HealthchecksioHelper,
+    StatusInfo,
+)
+from ansible.module_utils.basic import AnsibleModule
+
+
+def run(module):
+    StatusInfo(module).get()
+
+
+def main():
+    argument_spec = HealthchecksioHelper.healthchecksio_argument_spec()
+    argument_spec.pop("state", None)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    run(module)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/docker/bootstrap.py
+++ b/tests/docker/bootstrap.py
@@ -66,6 +66,11 @@ def main():
         help="Path to write the raw API key to",
     )
     parser.add_argument(
+        "--ping-key-output",
+        default="/tmp/hc_ci_ping_key.txt",
+        help="Path to write the project ping key",
+    )
+    parser.add_argument(
         "--service-name",
         default="web",
         help="Name of the web service in docker-compose (default: web)",
@@ -156,9 +161,12 @@ def main():
         + "project = Project.objects.create(owner=user, name='CI Test Project')\n"
         + "if hasattr(project, 'badge_key') and not project.badge_key:\n"
         + "    project.badge_key = uuid.uuid4().hex[:12]\n"
+        + "if not project.ping_key:\n"
+        + "    project.ping_key = uuid.uuid4().hex\n"
         + "raw_key = project.set_api_key()\n"
         + "project.save()\n"
         + "print(raw_key)\n"
+        + "print(project.ping_key)\n"
     )
 
     result = run_command(
@@ -179,8 +187,19 @@ def main():
         )
         sys.exit(1)
 
-    api_key = result.stdout.strip().split(b"\n")[-1].decode().strip()
-    if not api_key:
+    output_lines = [
+        line.decode().strip() for line in result.stdout.splitlines() if line.strip()
+    ]
+    if len(output_lines) < 2:
+        print(
+            "Error: API and ping keys were not returned. stdout: {0}".format(
+                result.stdout
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    api_key, ping_key = output_lines[-2:]
+    if not api_key or not ping_key:
         print(
             "Error: empty API key. stdout: {0}".format(result.stdout),
             file=sys.stderr,
@@ -189,9 +208,13 @@ def main():
 
     with open(args.api_key_output, "w", encoding="utf-8") as file_obj:
         file_obj.write(api_key + "\n")
+    with open(args.ping_key_output, "w", encoding="utf-8") as file_obj:
+        file_obj.write(ping_key + "\n")
 
     print(
-        "Bootstrap complete. API key written to {0}".format(args.api_key_output),
+        "Bootstrap complete. Keys written to {0} and {1}".format(
+            args.api_key_output, args.ping_key_output
+        ),
         file=sys.stderr,
     )
 

--- a/tests/docker/render_integration_config.py
+++ b/tests/docker/render_integration_config.py
@@ -12,6 +12,8 @@ def main():
     with open("/tmp/hc_ci_key.txt", encoding="utf-8") as file_obj:
         api_key = file_obj.read().strip()
     host = os.environ.get("HC_TEST_HOST", "127.0.0.1").strip()
+    with open("/tmp/hc_ci_ping_key.txt", encoding="utf-8") as file_obj:
+        ping_key = file_obj.read().strip()
     with open(
         "tests/integration/integration_config.yml.template", encoding="utf-8"
     ) as file_obj:
@@ -20,14 +22,14 @@ def main():
         "${MANAGEMENT_API_TOKEN:-$HEALTHCHECKSIO_API_TOKEN}", api_key
     )
     content = content.replace(
-        '${MANAGEMENT_API_BASE_URL:-"https://healthchecks.io/api/v1"}',
-        "http://{0}:8000/api/v1".format(host),
+        '${MANAGEMENT_API_BASE_URL:-"https://healthchecks.io/api/v3"}',
+        "http://{0}:8000/api/v3".format(host),
     )
     content = content.replace(
         '${PING_API_BASE_URL:-"https://hc-ping.com"}',
         "http://{0}:8000/ping".format(host),
     )
-    content = content.replace('${PING_API_TOKEN:-""}', "")
+    content = content.replace('${PING_API_TOKEN:-""}', ping_key)
     with open(
         "tests/integration/integration_config.yml", "w", encoding="utf-8"
     ) as file_obj:

--- a/tests/integration/integration_config.yml.template
+++ b/tests/integration/integration_config.yml.template
@@ -1,5 +1,5 @@
 ---
 api_key: ${MANAGEMENT_API_TOKEN:-$HEALTHCHECKSIO_API_TOKEN}
-management_api_base_url: ${MANAGEMENT_API_BASE_URL:-"https://healthchecks.io/api/v1"}
+management_api_base_url: ${MANAGEMENT_API_BASE_URL:-"https://healthchecks.io/api/v3"}
 ping_api_base_url: ${PING_API_BASE_URL:-"https://hc-ping.com"}
 ping_api_token: ${PING_API_TOKEN:-""}

--- a/tests/integration/targets/api_v3/tasks/main.yml
+++ b/tests/integration/targets/api_v3/tasks/main.yml
@@ -1,0 +1,185 @@
+---
+- name: Exercise Management API v3 and Pinging API coverage
+  block:
+    - name: Ensure API key is provided
+      ansible.builtin.fail:
+        msg: api_key needs to be defined in tests/integration/integration_config.yml
+      when: api_key is not defined or api_key | length == 0
+
+    - name: Verify service database connectivity
+      community.healthchecksio.status_info:
+        management_api_base_url: "{{ management_api_base_url }}"
+      register: service_status
+
+    - name: Generate invocation-unique identifiers
+      ansible.builtin.set_fact:
+        api_v3_runid: "{{ ansible_date_time.iso8601_micro | to_uuid }}"
+
+    - name: Create a check with the complete v3 configuration surface
+      community.healthchecksio.checks:
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        name: "API v3 {{ api_v3_runid }}"
+        slug: "api-v3-{{ api_v3_runid }}"
+        unique: [slug]
+        tags: [api-v3, integration]
+        desc: Initial API v3 description
+        timeout: 120
+        grace: 60
+        manual_resume: true
+        methods: POST
+        start_kw: STARTED
+        success_kw: COMPLETE
+        failure_kw: ERROR
+        filter_http_body: true
+        filter_default_fail: true
+      register: api_v3_check
+
+    - name: Record the v3 check UUID
+      ansible.builtin.set_fact:
+        api_v3_uuid: "{{ api_v3_check.uuid }}"
+
+    - name: Verify v3 create response fields
+      ansible.builtin.assert:
+        that:
+          - service_status.status == "ok"
+          - api_v3_check.changed
+          - api_v3_check.data.slug == "api-v3-" + api_v3_runid
+          - api_v3_check.data.tags == "api-v3 integration"
+          - api_v3_check.data.manual_resume
+          - api_v3_check.data.methods == "POST"
+          - api_v3_check.data.filter_http_body
+          - api_v3_check.data.filter_default_fail
+
+    - name: Find the check by v3 slug filter
+      community.healthchecksio.checks_info:
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        slug: "api-v3-{{ api_v3_runid }}"
+      register: slug_lookup
+
+    - name: Verify slug lookup
+      ansible.builtin.assert:
+        that:
+          - not slug_lookup.changed
+          - slug_lookup.data.checks | length == 1
+          - slug_lookup.data.checks[0].uuid == api_v3_uuid
+
+    - name: Explicitly update the check by UUID
+      community.healthchecksio.checks:
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        state: present
+        uuid: "{{ api_v3_uuid }}"
+        desc: Updated through the explicit v3 endpoint
+      register: explicit_update
+
+    - name: Repeat explicit update for idempotency
+      community.healthchecksio.checks:
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        state: present
+        uuid: "{{ api_v3_uuid }}"
+        desc: Updated through the explicit v3 endpoint
+      register: explicit_update_again
+
+    - name: Pause and resume the check
+      community.healthchecksio.checks:
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        state: pause
+        uuid: "{{ api_v3_uuid }}"
+      register: pause_result
+
+    - name: Resume the manually paused check
+      community.healthchecksio.checks:
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        state: resume
+        uuid: "{{ api_v3_uuid }}"
+      register: resume_result
+
+    - name: Verify update, idempotency, pause, and resume
+      ansible.builtin.assert:
+        that:
+          - explicit_update.changed
+          - explicit_update.data.desc == "Updated through the explicit v3 endpoint"
+          - not explicit_update_again.changed
+          - pause_result.changed
+          - resume_result.changed
+
+    - name: Send a log event with a diagnostic body
+      community.healthchecksio.ping:
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        uuid: "{{ api_v3_uuid }}"
+        signal: log
+        body: "api-v3-body-{{ api_v3_runid }}"
+      register: log_ping
+
+    - name: Wait for the logged body to appear in ping history
+      community.healthchecksio.checks_pings_info:
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        uuid: "{{ api_v3_uuid }}"
+      register: api_v3_history
+      until:
+        - api_v3_history.data.pings | length > 0
+        - api_v3_history.data.pings[0].body_url is not none
+      retries: 10
+      delay: 2
+
+    - name: Retrieve the stored ping body
+      community.healthchecksio.checks_ping_body_info:
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        uuid: "{{ api_v3_uuid }}"
+        sequence: "{{ api_v3_history.data.pings[0].n }}"
+      register: stored_body
+
+    - name: Report a successful process exit status
+      community.healthchecksio.ping:
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        uuid: "{{ api_v3_uuid }}"
+        exit_status: 0
+        method: POST
+      register: exit_status_ping
+
+    - name: Query recent status flips
+      community.healthchecksio.checks_flips_info:
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        uuid: "{{ api_v3_uuid }}"
+        seconds: 3600
+      register: recent_flips
+
+    - name: Verify ping body, exit status, and flip filtering
+      ansible.builtin.assert:
+        that:
+          - log_ping.changed
+          - stored_body.data == "api-v3-body-" + api_v3_runid
+          - exit_status_ping.changed
+          - recent_flips.data.flips is defined
+
+    - name: Ping by project key and slug
+      community.healthchecksio.ping:
+        ping_api_base_url: "{{ ping_api_base_url }}"
+        ping_api_token: "{{ ping_api_token }}"
+        slug: "api-v3-{{ api_v3_runid }}"
+        signal: success
+        method: POST
+      register: slug_ping
+      when: ping_api_token | default("", true) | length > 0
+
+    - name: Verify slug ping
+      ansible.builtin.assert:
+        that: slug_ping.changed
+      when: ping_api_token | default("", true) | length > 0
+
+  always:
+    - name: Delete the v3 integration check
+      community.healthchecksio.checks:
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        state: absent
+        uuid: "{{ api_v3_uuid }}"
+      when: api_v3_uuid is defined

--- a/tests/integration/targets/checks/tasks/main.yml
+++ b/tests/integration/targets/checks/tasks/main.yml
@@ -130,24 +130,31 @@
           - result.msg is defined
           - result.msg == "Check " ~ uuid ~ " successfully deleted"
 
-    - name: Create an invalid check (mutally exclusive)
+    - name: Verify schedule takes precedence over timeout without an explicit timezone
       community.healthchecksio.checks:
         state: present
         api_key: "{{ api_key }}"
         management_api_base_url: "{{ management_api_base_url }}"
         ping_api_base_url: "{{ ping_api_base_url }}"
-        name: simple test
+        name: schedule precedence test
         unique: ["name"]
         timeout: 77
         schedule: 7 7 * * *
       register: result
-      ignore_errors: true
 
-    - name: Verify integrations
+    - name: Verify schedule precedence
       ansible.builtin.assert:
         that:
-          - result.failed
-          - result.msg is search("parameters are mutually exclusive")
+          - result.changed
+          - result.data.schedule == "7 7 * * *"
+          - result.data.tz == "UTC"
+
+    - name: Delete the schedule precedence check
+      community.healthchecksio.checks:
+        state: absent
+        api_key: "{{ api_key }}"
+        management_api_base_url: "{{ management_api_base_url }}"
+        uuid: "{{ result.uuid }}"
 
     - name: Create a Cron check named "cron test grace"
       community.healthchecksio.checks:

--- a/tests/integration/targets/checks_flips_info/tasks/main.yml
+++ b/tests/integration/targets/checks_flips_info/tasks/main.yml
@@ -48,7 +48,7 @@
         that:
           - not result.changed
           - result.data is defined
-          - result.data.flips is defined
+          - result.data is iterable
 
     - name: Pause for ten seconds
       ansible.builtin.pause:

--- a/tests/integration/targets/ping/tasks/main.yml
+++ b/tests/integration/targets/ping/tasks/main.yml
@@ -58,7 +58,7 @@
         that:
           - result.changed
           - result.msg is defined
-          - "result.msg == 'Sent start signal to ' + uuid + '/start'"
+          - "result.msg == 'Sent start signal to ' + uuid"
 
     - name: Send fail signal
       community.healthchecksio.ping:
@@ -75,7 +75,7 @@
         that:
           - result.changed
           - result.msg is defined
-          - "result.msg == 'Sent fail signal to ' + uuid + '/fail'"
+          - "result.msg == 'Sent fail signal to ' + uuid"
 
     - name: Send success signal
       community.healthchecksio.ping:
@@ -110,7 +110,7 @@
         that:
           - result.changed
           - result.msg is defined
-          - "result.msg == 'Sent start signal to ' + uuid + '/start'"
+          - "result.msg == 'Sent start signal to ' + uuid"
 
     - name: Send success signal with the same run ID
       community.healthchecksio.ping:

--- a/tests/unit/plugins/module_utils/test_healthchecksio.py
+++ b/tests/unit/plugins/module_utils/test_healthchecksio.py
@@ -15,10 +15,12 @@ from ansible_collections.community.healthchecksio.plugins.module_utils.healthche
     Checks,
     ChecksFlipsInfo,
     ChecksInfo,
+    ChecksPingBodyInfo,
     ChecksPingsInfo,
     HealthchecksioHelper,
     HealthchecksioPingHelper,
     Response,
+    StatusInfo,
 )
 
 
@@ -45,7 +47,7 @@ def module(**overrides):
     params = dict(
         state="present",
         management_api_token="token",
-        management_api_base_url="https://healthchecks.io/api/v1",
+        management_api_base_url="https://healthchecks.io/api/v3",
         ping_api_base_url="https://hc-ping.com",
         ping_api_token=None,
         validate_certs=True,
@@ -137,8 +139,8 @@ def test_helper_rejects_invalid_token(fetch):
 @patch(PATH + ".fetch_url", side_effect=lambda *args, **kwargs: fetch_success())
 def test_helper_builds_urls(fetch):
     helper = HealthchecksioHelper(module())
-    assert helper._url_builder("checks") == "https://healthchecks.io/api/v1/checks"
-    assert helper._url_builder("/checks") == "https://healthchecks.io/api/v1/checks"
+    assert helper._url_builder("checks") == "https://healthchecks.io/api/v3/checks"
+    assert helper._url_builder("/checks") == "https://healthchecks.io/api/v3/checks"
 
 
 @pytest.mark.parametrize(
@@ -156,23 +158,12 @@ def test_helper_dispatches_methods(fetch, name, method):
 
 
 @patch(PATH + ".fetch_url", side_effect=lambda *args, **kwargs: fetch_success())
-def test_helper_delete_omits_null_body(fetch):
+def test_helper_delete_omits_body(fetch):
     mod = module()
-    mod.jsonify.return_value = "null"
     helper = HealthchecksioHelper(mod)
     helper.delete("checks/id")
     assert fetch.call_args[1]["data"] is None
-
-
-@pytest.mark.parametrize("no_headers", [False, True])
-@patch(PATH + ".fetch_url", side_effect=lambda *args, **kwargs: fetch_success())
-def test_helper_head_headers(fetch, no_headers):
-    helper = HealthchecksioHelper(module())
-    helper.head("id", data=b"x", no_headers=no_headers)
-    kwargs = fetch.call_args[1]
-    assert kwargs["method"] == "HEAD"
-    assert kwargs["data"] == b"x"
-    assert ("headers" not in kwargs) is no_headers
+    mod.jsonify.assert_not_called()
 
 
 def test_argument_spec():
@@ -180,7 +171,7 @@ def test_argument_spec():
     assert spec["state"]["choices"] == ["present", "absent"]
     assert spec["management_api_token"]["no_log"] is True
     assert (
-        spec["management_api_base_url"]["default"] == "https://healthchecks.io/api/v1"
+        spec["management_api_base_url"]["default"] == "https://healthchecks.io/api/v3"
     )
     assert spec["ping_api_base_url"]["default"] == "https://hc-ping.com"
     assert spec["validate_certs"]["default"] is True
@@ -188,7 +179,7 @@ def test_argument_spec():
 
 
 @pytest.mark.parametrize(
-    "ping_token,expected", [("ping", "ping"), ("", "token"), (None, None)]
+    "ping_token,expected", [("ping", "ping"), ("", ""), (None, None)]
 )
 def test_ping_helper_settings(ping_token, expected):
     helper = HealthchecksioPingHelper.__new__(HealthchecksioPingHelper)
@@ -247,6 +238,8 @@ def test_check_events(cls, suffix, status, exception):
         ({"tags": []}, "checks"),
         ({"tags": ["prod", "web"]}, "checks?tag=prod&tag=web"),
         ({"uuid": "abc"}, "checks/abc"),
+        ({"unique_key": "readonly"}, "checks/readonly"),
+        ({"slug": "nightly/job"}, "checks?slug=nightly%2Fjob"),
         ({"name": "nightly job"}, "checks?name=nightly%20job"),
         ({"tags": ["prod"], "name": "a/b"}, "checks?tag=prod&name=a%2Fb"),
     ],
@@ -296,7 +289,7 @@ def check_params(**overrides):
         validate_certs=True,
         request_timeout=30,
         management_api_token="token",
-        management_api_base_url="https://healthchecks.io/api/v1",
+        management_api_base_url="https://healthchecks.io/api/v3",
         ping_api_token=None,
         ping_api_base_url="https://hc-ping.com",
     )
@@ -313,6 +306,7 @@ def existing(**overrides):
         tz=None,
         channels="email,slack",
         tags="prod web",
+        grace=3600,
         ping_url="https://hc-ping.com/abc",
     )
     result.update(overrides)
@@ -325,13 +319,25 @@ def checks(**overrides):
 
 def request_params(obj):
     result = dict(obj.module.params)
-    for key in ("uuid", "state", "validate_certs", "request_timeout"):
+    for key in (
+        "uuid",
+        "state",
+        "api_key",
+        "management_api_key",
+        "management_api_token",
+        "management_api_base_url",
+        "ping_api_token",
+        "ping_api_base_url",
+        "validate_certs",
+        "request_timeout",
+    ):
         result.pop(key, None)
-    if result.get("schedule") and result.get("tz"):
-        result.pop("timeout")
+    result = dict((key, value) for key, value in result.items() if value is not None)
+    if result.get("schedule"):
+        result.pop("timeout", None)
     if result.get("timeout"):
-        result.pop("schedule")
-        result.pop("tz")
+        result.pop("schedule", None)
+        result.pop("tz", None)
     result["tags"] = " ".join(obj.module.params.get("tags", []))
     return result
 
@@ -359,14 +365,17 @@ def test_find_existing_channel_order():
     assert obj._find_existing_check(request_params(obj)) == found
 
 
-def test_find_existing_resolves_all_channels():
+def test_find_existing_resolves_all_channels_once():
     obj = checks(channels="*")
     found = existing()
     obj.rest.get.side_effect = [
         response(data={"checks": [found]}),
         response(data={"channels": [{"id": "email"}, {"id": "slack"}]}),
     ]
-    assert obj._find_existing_check(request_params(obj)) == found
+    params = request_params(obj)
+    assert obj._find_existing_check(params) == found
+    assert obj._matches(found, params) is True
+    assert obj.rest.get.call_count == 2
 
 
 def test_find_existing_ambiguous_unique_fails():
@@ -377,10 +386,11 @@ def test_find_existing_ambiguous_unique_fails():
     assert "2 found" in result_kwargs(obj.module)["msg"]
 
 
-def test_find_existing_empty_unique_allows_multiple():
+def test_find_existing_without_unique_always_creates():
     obj = checks(unique=[])
-    obj.rest.get.return_value = response(data={"checks": [existing(), existing()]})
+    obj.rest.get.return_value = response(data={"checks": [existing()]})
     assert obj._find_existing_check(request_params(obj)) is None
+    obj.rest.get.assert_not_called()
 
 
 @pytest.mark.parametrize("found,changed", [(existing(), False), (None, True)])
@@ -416,7 +426,7 @@ def test_create_idempotent_with_all_channels():
 
 
 def test_create_simple_payload():
-    obj = checks()
+    obj = checks(api_key="alias-token", management_api_key="alias-token")
     obj._find_existing_check = MagicMock(return_value=None)
     obj.rest.post.return_value = response(201, existing())
     with pytest.raises(ExitJson) as exc:
@@ -424,9 +434,29 @@ def test_create_simple_payload():
     payload = obj.rest.post.call_args[1]["data"]
     assert payload["tags"] == "prod web"
     assert payload["timeout"] == 60
-    for key in ("schedule", "tz", "uuid", "state", "validate_certs", "request_timeout"):
+    for key in (
+        "schedule",
+        "tz",
+        "uuid",
+        "state",
+        "api_key",
+        "management_api_key",
+        "management_api_token",
+        "validate_certs",
+        "request_timeout",
+    ):
         assert key not in payload
     assert result_kwargs(obj.module)["msg"] == "New check abc created"
+
+
+@pytest.mark.parametrize("alias", ["api_key", "management_api_key"])
+def test_create_strips_management_api_key_aliases(alias):
+    obj = checks(**{alias: "token-alias"})
+    obj._find_existing_check = MagicMock(return_value=existing())
+    with pytest.raises(ExitJson):
+        obj.create()
+    assert result_kwargs(obj.module)["changed"] is False
+    obj.rest.post.assert_not_called()
 
 
 def test_create_cron_payload():
@@ -442,7 +472,7 @@ def test_create_cron_payload():
 
 def test_create_updates_changed_check():
     obj = checks(slug="new")
-    obj._find_existing_check = MagicMock(return_value=existing())
+    obj._find_existing_check = MagicMock(return_value=None)
     obj.rest.post.return_value = response(200, existing(slug="new"))
     with pytest.raises(ExitJson) as exc:
         obj.create()
@@ -496,3 +526,143 @@ def test_destructive_results(
     getattr(obj.rest, http_method).assert_called_once_with("checks/abc" + suffix)
     assert result_kwargs(obj.module)["changed"] is changed
     assert text in result_kwargs(obj.module)["msg"]
+
+
+def test_resume_check_mode():
+    obj = checks(uuid="abc")
+    obj.module.check_mode = True
+    with pytest.raises(ExitJson):
+        obj.resume()
+    assert result_kwargs(obj.module)["changed"] is True
+    assert result_kwargs(obj.module)["uuid"] == "abc"
+    obj.rest.post.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "status,changed,text,exception",
+    [
+        (200, True, "successfully resumed", ExitJson),
+        (404, False, "not found", ExitJson),
+        (409, False, "not paused", ExitJson),
+        (500, False, "HTTP 500", FailJson),
+    ],
+)
+def test_resume_results(status, changed, text, exception):
+    obj = checks(uuid="abc")
+    obj.rest.post.return_value = response(status)
+    with pytest.raises(exception):
+        obj.resume()
+    obj.rest.post.assert_called_once_with("checks/abc/resume")
+    assert result_kwargs(obj.module)["changed"] is changed
+    assert text in result_kwargs(obj.module)["msg"]
+
+
+def test_response_exposes_plain_text_body():
+    resp = MagicMock()
+    resp.read.return_value = b"diagnostic output"
+    assert Response(resp, {"status": 200}).text == "diagnostic output"
+    assert Response(None, {"status": 404, "body": b"missing"}).text == "missing"
+    assert Response(None, {"status": 204}).text is None
+
+
+@patch(PATH + ".fetch_url")
+def test_ping_helper_does_not_probe_management_endpoint(fetch):
+    mod = module(ping_api_token="ping-key")
+    mod.params.pop("request_timeout")
+    helper = HealthchecksioPingHelper(mod)
+    assert helper.api_token == "ping-key"
+    assert helper.request_timeout == 30
+    fetch.assert_not_called()
+
+
+@patch(PATH + ".fetch_url")
+def test_ping_helper_sends_raw_body(fetch):
+    fetch.return_value = fetch_success()
+    helper = HealthchecksioPingHelper(module())
+    helper.ping("POST", "abc/log", "diagnostic")
+    assert fetch.call_args[1]["method"] == "POST"
+    assert fetch.call_args[1]["data"] == b"diagnostic"
+    assert fetch.call_args[1]["headers"] == {
+        "Content-Type": "text/plain; charset=utf-8"
+    }
+
+
+@pytest.mark.parametrize(
+    "cls,authenticate",
+    [(ChecksPingBodyInfo, True), (StatusInfo, False)],
+)
+@patch(PATH + ".HealthchecksioHelper")
+def test_info_service_constructors(helper, cls, authenticate):
+    mod = module()
+    obj = cls(mod)
+    assert obj.module is mod
+    if authenticate:
+        helper.assert_called_once_with(mod)
+    else:
+        helper.assert_called_once_with(mod, authenticate=False)
+    assert obj.rest is helper.return_value
+
+
+def test_ping_body_success_and_failure():
+    obj = service(ChecksPingBodyInfo, module(uuid="abc", sequence=7))
+    obj.rest.get.return_value = response(data={})
+    obj.rest.get.return_value.text = "stored output"
+    with pytest.raises(ExitJson):
+        obj.get()
+    obj.rest.get.assert_called_once_with("checks/abc/pings/7/body")
+    assert result_kwargs(obj.module)["data"] == "stored output"
+
+    obj = service(ChecksPingBodyInfo, module(uuid="abc", sequence=8))
+    obj.rest.get.return_value = response(404)
+    with pytest.raises(FailJson):
+        obj.get()
+    assert "HTTP 404" in result_kwargs(obj.module)["msg"]
+
+
+@pytest.mark.parametrize("status,exception", [(200, ExitJson), (500, FailJson)])
+def test_status_info(status, exception):
+    obj = service(StatusInfo)
+    obj.rest.get.return_value = response(status)
+    with pytest.raises(exception):
+        obj.get()
+    obj.rest.get.assert_called_once_with("status/")
+    if status == 200:
+        assert result_kwargs(obj.module)["status"] == "ok"
+
+
+@pytest.mark.parametrize(
+    "params,endpoint",
+    [
+        ({"uuid": "abc", "seconds": 60}, "checks/abc/flips?seconds=60"),
+        (
+            {"unique_key": "readonly", "start": 100, "end": 200},
+            "checks/readonly/flips?start=100&end=200",
+        ),
+    ],
+)
+def test_flips_filters(params, endpoint):
+    obj = service(ChecksFlipsInfo, module(**params))
+    obj.rest.get.return_value = response(data=[])
+    with pytest.raises(ExitJson):
+        obj.get()
+    obj.rest.get.assert_called_once_with(endpoint)
+
+
+def test_get_uuid_prefers_v3_uuid_field():
+    assert (
+        service(Checks).get_uuid({"uuid": "direct", "ping_url": "x/other"}) == "direct"
+    )
+
+
+def test_explicit_update_uses_uuid_endpoint_and_omits_upsert_fields():
+    obj = checks(uuid="abc", slug="updated")
+    obj.rest.get.return_value = response(200, existing(uuid="abc", slug="old"))
+    obj.rest.post.return_value = response(200, existing(uuid="abc", slug="updated"))
+    with pytest.raises(ExitJson):
+        obj.create()
+    endpoint = obj.rest.post.call_args[0][0]
+    payload = obj.rest.post.call_args[1]["data"]
+    assert endpoint == "checks/abc"
+    assert "unique" not in payload
+    assert payload["slug"] == "updated"
+    assert "management_api_token" not in payload

--- a/tests/unit/plugins/modules/test_checks.py
+++ b/tests/unit/plugins/modules/test_checks.py
@@ -18,7 +18,12 @@ from ansible_collections.community.healthchecksio.tests.unit.plugins.modules.uti
 
 @pytest.mark.parametrize(
     ("state", "method"),
-    [("present", "create"), ("absent", "delete"), ("pause", "pause")],
+    [
+        ("present", "create"),
+        ("absent", "delete"),
+        ("pause", "pause"),
+        ("resume", "resume"),
+    ],
 )
 def test_run_dispatches_state(state, method):
     module = make_module(state=state)
@@ -35,6 +40,7 @@ def test_run_ignores_unknown_state():
     checks_class.return_value.create.assert_not_called()
     checks_class.return_value.delete.assert_not_called()
     checks_class.return_value.pause.assert_not_called()
+    checks_class.return_value.resume.assert_not_called()
 
 
 def test_main_builds_state_constraints_and_runs_module():
@@ -45,14 +51,14 @@ def test_main_builds_state_constraints_and_runs_module():
     assert kwargs["required_if"] == [
         ("state", "absent", ["uuid"]),
         ("state", "pause", ["uuid"]),
+        ("state", "resume", ["uuid"]),
     ]
-    assert kwargs["required_together"] == [("schedule", "tz")]
-    assert kwargs["mutually_exclusive"] == [
-        ("timeout", "schedule"),
-        ("timeout", "tz"),
-    ]
+    assert kwargs["required_by"] == {"tz": "schedule"}
+    assert "required_together" not in kwargs
+    assert "mutually_exclusive" not in kwargs
     assert kwargs["argument_spec"]["state"]["choices"] == [
         "present",
         "absent",
         "pause",
+        "resume",
     ]

--- a/tests/unit/plugins/modules/test_checks_flips_info.py
+++ b/tests/unit/plugins/modules/test_checks_flips_info.py
@@ -37,3 +37,8 @@ def test_main_builds_check_mode_module_and_runs_it():
     kwargs = ansible_module.call_args[1]
     assert kwargs["supports_check_mode"] is True
     assert kwargs["argument_spec"]["uuid"] == dict(type="str", required=False)
+    assert kwargs["required_one_of"] == [("uuid", "unique_key")]
+    assert ("seconds", "start") in kwargs["mutually_exclusive"]
+    assert set(("unique_key", "seconds", "start", "end")) <= set(
+        kwargs["argument_spec"]
+    )

--- a/tests/unit/plugins/modules/test_checks_info.py
+++ b/tests/unit/plugins/modules/test_checks_info.py
@@ -34,5 +34,8 @@ def test_main_builds_filters_and_runs_module():
     ansible_module = run_main(checks_info, module)
     kwargs = ansible_module.call_args[1]
     assert kwargs["supports_check_mode"] is True
-    assert kwargs["mutually_exclusive"] == [("tags", "uuid"), ("name", "uuid")]
-    assert set(("tags", "uuid", "name")) <= set(kwargs["argument_spec"])
+    assert ("uuid", "unique_key") in kwargs["mutually_exclusive"]
+    assert ("uuid", "slug") in kwargs["mutually_exclusive"]
+    assert set(("tags", "uuid", "unique_key", "slug", "name")) <= set(
+        kwargs["argument_spec"]
+    )

--- a/tests/unit/plugins/modules/test_checks_ping_body_info.py
+++ b/tests/unit/plugins/modules/test_checks_ping_body_info.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+from ansible_collections.community.healthchecksio.plugins.modules import (
+    checks_ping_body_info,
+)
+from ansible_collections.community.healthchecksio.tests.unit.plugins.modules.utils import (
+    make_module,
+    run_main,
+)
+
+
+def test_run_gets_ping_body():
+    module = make_module()
+    with patch.object(checks_ping_body_info, "ChecksPingBodyInfo") as body_info:
+        checks_ping_body_info.run(module)
+    body_info.assert_called_once_with(module)
+    body_info.return_value.get.assert_called_once_with()
+
+
+def test_main_requires_uuid_and_sequence():
+    module = make_module()
+    ansible_module = run_main(checks_ping_body_info, module)
+    kwargs = ansible_module.call_args[1]
+    assert kwargs["supports_check_mode"] is True
+    assert "state" not in kwargs["argument_spec"]
+    assert kwargs["argument_spec"]["uuid"]["required"] is True
+    assert kwargs["argument_spec"]["sequence"] == dict(type="int", required=True)

--- a/tests/unit/plugins/modules/test_checks_pings_info.py
+++ b/tests/unit/plugins/modules/test_checks_pings_info.py
@@ -36,4 +36,4 @@ def test_main_builds_check_mode_module_and_runs_it():
     ansible_module = run_main(checks_pings_info, module)
     kwargs = ansible_module.call_args[1]
     assert kwargs["supports_check_mode"] is True
-    assert kwargs["argument_spec"]["uuid"] == dict(type="str", required=False)
+    assert kwargs["argument_spec"]["uuid"] == dict(type="str", required=True)

--- a/tests/unit/plugins/modules/test_ping.py
+++ b/tests/unit/plugins/modules/test_ping.py
@@ -31,7 +31,7 @@ class FailJson(Exception):
 def _make_module(**overrides):
     params = {
         "management_api_token": "test-token",
-        "management_api_base_url": "https://healthchecks.io/api/v1",
+        "management_api_base_url": "https://healthchecks.io/api/v3",
         "ping_api_base_url": "https://hc-ping.com",
         "ping_api_token": None,
         "validate_certs": True,
@@ -41,74 +41,89 @@ def _make_module(**overrides):
     module = MagicMock()
     module.params = params
     module.check_mode = False
-    module.jsonify.side_effect = lambda value: value
     module.exit_json.side_effect = ExitJson
     module.fail_json.side_effect = FailJson
     return module
 
 
-def _mock_fetch(status=200, body=b'{"checks": []}'):
+def _mock_fetch(status=200, body=b"OK"):
     resp = MagicMock()
     resp.read.return_value = body
     return resp, {"status": status}
-
-
-def _last_fetch_url(mock_fetch_url):
-    return mock_fetch_url.call_args_list[-1][0][1]
 
 
 @patch(
     "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url"
 )
 @pytest.mark.parametrize(
-    ("signal", "endpoint"),
+    "signal,endpoint",
     [
         ("success", "check-uuid"),
         ("start", "check-uuid/start"),
         ("fail", "check-uuid/fail"),
+        ("log", "check-uuid/log"),
     ],
 )
-def test_ping_create_sends_each_signal(mock_fetch_url, signal, endpoint):
-    mock_fetch_url.return_value = _mock_fetch()
+def test_ping_create_sends_uuid_signals(fetch, signal, endpoint):
+    fetch.return_value = _mock_fetch()
     module = _make_module()
     with pytest.raises(ExitJson):
         Ping(module).create("check-uuid", signal)
-    assert _last_fetch_url(mock_fetch_url) == "https://hc-ping.com/" + endpoint
-    module.exit_json.assert_called_once_with(
-        changed=True,
-        msg="Sent {0} signal to {1}".format(signal, endpoint),
-    )
+    assert fetch.call_args[0][1] == "https://hc-ping.com/" + endpoint
+    assert fetch.call_args[1]["method"] == "HEAD"
+    assert fetch.call_args[1]["headers"] is None
 
 
 @patch(
     "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url"
 )
-def test_ping_create_appends_encoded_runid_as_rid_query_param(mock_fetch_url):
-    mock_fetch_url.return_value = _mock_fetch()
+def test_ping_create_supports_slug_runid_body_and_create(fetch):
+    fetch.return_value = _mock_fetch(status=201)
+    module = _make_module(ping_api_token="project-key")
+    with pytest.raises(ExitJson):
+        Ping(module).create(
+            slug="backup",
+            signal="start",
+            runid="run id/1",
+            body="diagnostic",
+            create=True,
+        )
+    assert fetch.call_args[0][1] == (
+        "https://hc-ping.com/project-key/backup/start?rid=run%20id%2F1&create=1"
+    )
+    assert fetch.call_args[1]["method"] == "POST"
+    assert fetch.call_args[1]["data"] == b"diagnostic"
+    assert fetch.call_args[1]["headers"] == {
+        "Content-Type": "text/plain; charset=utf-8"
+    }
+    assert module.exit_json.call_args[1]["msg"] == "Sent start signal to backup"
+    assert "project-key" not in module.exit_json.call_args[1]["msg"]
+
+
+@patch(
+    "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url"
+)
+def test_ping_create_reports_exit_status(fetch):
+    fetch.return_value = _mock_fetch()
     module = _make_module()
     with pytest.raises(ExitJson):
-        Ping(module).create("check-uuid", "start", "run id/1")
-    assert (
-        _last_fetch_url(mock_fetch_url)
-        == "https://hc-ping.com/check-uuid/start?rid=run%20id%2F1"
-    )
-    module.exit_json.assert_called_once_with(
-        changed=True,
-        msg="Sent start signal to check-uuid/start",
-    )
+        Ping(module).create(uuid="check-uuid", exit_status=17, method="GET")
+    assert fetch.call_args[0][1] == "https://hc-ping.com/check-uuid/17"
+    assert fetch.call_args[1]["method"] == "GET"
+    assert "17 signal" in module.exit_json.call_args[1]["msg"]
 
 
 @patch(
     "ansible_collections.community.healthchecksio.plugins.module_utils.healthchecksio.fetch_url"
 )
-def test_ping_create_reports_http_failure(mock_fetch_url):
-    mock_fetch_url.return_value = _mock_fetch(status=503)
+def test_ping_create_reports_http_failure(fetch):
+    fetch.return_value = _mock_fetch(status=503)
     module = _make_module()
     with pytest.raises(FailJson):
         Ping(module).create("check-uuid", "fail")
     module.fail_json.assert_called_once_with(
         changed=False,
-        msg="Failed to send fail signal to check-uuid/fail [HTTP 503]",
+        msg="Failed to send fail signal to check-uuid [HTTP 503]",
     )
 
 
@@ -116,33 +131,101 @@ def test_ping_create_is_noop_in_check_mode():
     module = _make_module()
     module.check_mode = True
     with pytest.raises(ExitJson):
-        Ping(module).create("check-uuid", "success")
+        Ping(module).create("check-uuid")
     module.exit_json.assert_called_once_with(changed=False, data={})
 
 
-def test_run_passes_runid_to_ping():
+def test_run_passes_complete_request_to_ping():
     module = _make_module(
         state="present",
-        uuid="check-uuid",
-        signal="success",
+        uuid=None,
+        slug="backup",
+        signal="log",
+        exit_status=None,
         runid="728b3763-ea80-4113-9fc0-f49b3adf226a",
+        body="output",
+        method="POST",
+        create=True,
+        ping_api_token="project-key",
     )
     with patch.object(ping_module, "Ping") as ping_class:
         ping_module.run(module)
     ping_class.return_value.create.assert_called_once_with(
-        "check-uuid",
-        "success",
-        "728b3763-ea80-4113-9fc0-f49b3adf226a",
+        uuid=None,
+        slug="backup",
+        signal="log",
+        runid="728b3763-ea80-4113-9fc0-f49b3adf226a",
+        body="output",
+        method="POST",
+        create=True,
+        exit_status=None,
     )
+
+
+def test_run_uses_public_ping_defaults_when_parameters_are_missing():
+    module = _make_module(
+        state="present",
+        uuid="abc",
+        slug=None,
+        exit_status=None,
+    )
+    with patch.object(ping_module, "Ping") as ping_class:
+        ping_module.run(module)
+    ping_class.return_value.create.assert_called_once_with(
+        uuid="abc",
+        slug=None,
+        signal="success",
+        runid=None,
+        body=None,
+        method="HEAD",
+        create=False,
+        exit_status=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "params,text",
+    [
+        ({"state": "present", "slug": "backup", "uuid": None}, "ping_api_token"),
+        (
+            {
+                "state": "present",
+                "slug": None,
+                "uuid": "abc",
+                "create": True,
+            },
+            "only supported",
+        ),
+        (
+            {
+                "state": "present",
+                "slug": None,
+                "uuid": "abc",
+                "exit_status": 256,
+            },
+            "between 0 and 255",
+        ),
+        (
+            {
+                "state": "present",
+                "slug": None,
+                "uuid": "abc",
+                "body": "diagnostic",
+                "method": "GET",
+            },
+            "cannot be used",
+        ),
+    ],
+)
+def test_run_validates_conditional_inputs(params, text):
+    module = _make_module(**params)
+    with pytest.raises(FailJson):
+        ping_module.run(module)
+    assert text in module.fail_json.call_args[1]["msg"]
 
 
 def test_run_ignores_unknown_state():
-    module = _make_module(
-        state="unknown",
-        uuid="check-uuid",
-        signal="success",
-        runid=None,
-    )
+    module = _make_module(state="unknown")
     with patch.object(ping_module, "Ping") as ping_class:
         ping_module.run(module)
     ping_class.return_value.create.assert_not_called()
@@ -153,10 +236,18 @@ def test_main_builds_ping_arguments_and_runs_module():
     ansible_module = run_main(ping_module, module)
     kwargs = ansible_module.call_args[1]
     assert kwargs["supports_check_mode"] is True
-    assert kwargs["argument_spec"]["uuid"] == dict(type="str", required=True)
+    assert kwargs["required_one_of"] == [("uuid", "slug")]
+    assert kwargs["mutually_exclusive"] == [("uuid", "slug")]
     assert kwargs["argument_spec"]["signal"]["choices"] == [
         "success",
         "fail",
         "start",
+        "log",
     ]
-    assert kwargs["argument_spec"]["runid"] == dict(type="str", required=False)
+    assert kwargs["argument_spec"]["method"]["choices"] == ["HEAD", "GET", "POST"]
+    assert kwargs["argument_spec"]["signal"]["default"] == "success"
+    assert kwargs["argument_spec"]["method"]["default"] == "HEAD"
+    assert kwargs["argument_spec"]["create"]["default"] is False
+    assert set(("slug", "exit_status", "body", "create")) <= set(
+        kwargs["argument_spec"]
+    )

--- a/tests/unit/plugins/modules/test_status_info.py
+++ b/tests/unit/plugins/modules/test_status_info.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+from ansible_collections.community.healthchecksio.plugins.modules import status_info
+from ansible_collections.community.healthchecksio.tests.unit.plugins.modules.utils import (
+    make_module,
+    run_main,
+)
+
+
+def test_run_gets_status():
+    module = make_module()
+    with patch.object(status_info, "StatusInfo") as status:
+        status_info.run(module)
+    status.assert_called_once_with(module)
+    status.return_value.get.assert_called_once_with()
+
+
+def test_main_does_not_require_state_or_api_key():
+    module = make_module()
+    ansible_module = run_main(status_info, module)
+    kwargs = ansible_module.call_args[1]
+    assert kwargs["supports_check_mode"] is True
+    assert "state" not in kwargs["argument_spec"]
+    assert kwargs["argument_spec"]["management_api_token"]["required"] is False


### PR DESCRIPTION
## Summary

- default the collection to Management API v3 and document complete endpoint coverage
- cover missing management endpoints: resume, ping bodies, status, slug and read-only-key lookups, and flip filters
- cover the complete Pinging API surface: slug addressing, logs, diagnostic bodies, exit statuses, HTTP methods, run IDs, and auto-create
- make explicit UUID updates idempotent without leaking connection settings or overwriting omitted fields
- add consolidated hosted and self-hosted API v3 integration coverage
- add a repository-owned release skill that enforces the merge, Zuul/Galaxy publication, GitHub release, and post-release bump lifecycle

## Breaking changes

This is a 2.0.0 release candidate:

- the default management endpoint changes from `/api/v1` to `/api/v3`
- `checks_pings_info.uuid` is required
- `checks_flips_info` requires `uuid` or `unique_key`
- `checks` accepts schedule precedence over timeout and requires `schedule` when `tz` is supplied

Existing self-hosted deployments can continue to pin `management_api_base_url`.

## API audit

Audited against:

- https://healthchecks.io/docs/api/
- https://healthchecks.io/docs/http_api/

The maintained mapping is in `docs/API_COVERAGE.md`.

## Verification

- 124 unit tests pass
- 95.53% local branch coverage; Codecov project coverage exceeds 90%
- Black formatting passes
- Ansible compile, import, PEP8, validate-modules, and yamllint sanity checks pass
- hosted and self-hosted live integration coverage passes
- `.agents/skills/release-healthchecksio` passes the official skill validator