### PR TITLE
chore: bump development version to 2.0.1-dev0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: community
 name: healthchecksio
-version: 2.0.0
+version: 2.0.1-dev0
 readme: README.md
 authors:
   - Mark Mercado (https://github.com/mamercad)


### PR DESCRIPTION
## Summary

Restore the collection development version after the verified 2.0.0 release.

## Validation

- `galaxy.yml` parses successfully
- version is exactly `2.0.1-dev0`
- only `galaxy.yml` changes
- `git diff --check` passes

Released version: https://github.com/ansible-collections/community.healthchecksio/releases/tag/2.0.0
Galaxy: https://galaxy.ansible.com/ui/repo/published/community/healthchecksio/?version=2.0.0